### PR TITLE
Close out the Tailwind migration in the repo docs

### DIFF
--- a/.weaverse/specs/2026-08-20--tailwind-presentation-migration/README.md
+++ b/.weaverse/specs/2026-08-20--tailwind-presentation-migration/README.md
@@ -1,10 +1,13 @@
 # Tailwind presentation migration
 
-Updated: 2026-08-21 07:07 +07
-Status: `SPEC_READY`
-Issue: [Weaverse/forward#61](https://github.com/Weaverse/forward/issues/61)
+Updated: 2026-09-07
+Status: `completed`
+Issue: [Weaverse/forward#61](https://github.com/Weaverse/forward/issues/61) (closed)
+Pull request: [Weaverse/forward#62](https://github.com/Weaverse/forward/pull/62) (merged)
 Branch: `refactor/tailwind-presentation-layer`
 Baseline: `main@8fa94b727cc7977d75dc2400bcddf8b2d492e83f`
+Merged as: `main@eb2df4c`
+Implementation head: `3050934`
 
 ## Objective
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,14 +5,24 @@
 Forward is a fresh Next.js App Router storefront theme using
 `@shopify/hydrogen@preview`, powered by Weaverse.
 
-The current milestone is the issue [#61](https://github.com/Weaverse/forward/issues/61)
-**Tailwind presentation migration**
-(`.weaverse/specs/2026-08-20--tailwind-presentation-migration/README.md`).
-Production polish Phase 1 is complete on `main@8fa94b7`. Migrate in the locked
-order: behavior-level UI coverage → effective Tailwind v4 tokens → global shell
-→ complete route inventory → ownership/runtime hardening → legacy CSS removal.
-This is an architecture migration, not a visual redesign. Preserve the accepted
-Production storefront and its live Shopify contracts.
+The Tailwind presentation migration, issue
+[#61](https://github.com/Weaverse/forward/issues/61)
+(`.weaverse/specs/2026-08-20--tailwind-presentation-migration/README.md`), is
+complete and merged as `main@eb2df4c`. Presentation now lives in Tailwind
+utilities owned by components and routes; there is no active migration in
+flight. Preserve the accepted Production storefront and its live Shopify
+contracts.
+
+Known follow-up work, none of it blocking:
+
+- `src/components/site-header/field-index-header.tsx` is 793 lines of client
+  code for navigation that is mostly static (issue #61 finding 7). Deferred.
+- Biome's `assist/source/organizeImports` reports 34 files, and neither
+  `bun run lint` nor `bun run format:check` currently enforces assist actions.
+- The Phase 5 proofs that no consumer references a retired presentation class,
+  and that Tailwind utilities span the presentation inventory, were deleted
+  with their guard scripts. The retired stylesheets themselves are still
+  guarded, so a stale class string is inert rather than harmful.
 
 ## Architecture constraints
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,25 +5,6 @@
 Forward is a fresh Next.js App Router storefront theme using
 `@shopify/hydrogen@preview`, powered by Weaverse.
 
-The Tailwind presentation migration, issue
-[#61](https://github.com/Weaverse/forward/issues/61)
-(`.weaverse/specs/2026-08-20--tailwind-presentation-migration/README.md`), is
-complete and merged as `main@eb2df4c`. Presentation now lives in Tailwind
-utilities owned by components and routes; there is no active migration in
-flight. Preserve the accepted Production storefront and its live Shopify
-contracts.
-
-Known follow-up work, none of it blocking:
-
-- `src/components/site-header/field-index-header.tsx` is 793 lines of client
-  code for navigation that is mostly static (issue #61 finding 7). Deferred.
-- Biome's `assist/source/organizeImports` reports 34 files, and neither
-  `bun run lint` nor `bun run format:check` currently enforces assist actions.
-- The Phase 5 proofs that no consumer references a retired presentation class,
-  and that Tailwind utilities span the presentation inventory, were deleted
-  with their guard scripts. The retired stylesheets themselves are still
-  guarded, so a stale class string is inert rather than harmful.
-
 ## Architecture constraints
 
 - Implement from scratch in this repository.


### PR DESCRIPTION
Docs-only follow-up to #62, which merged as `main@eb2df4c`.

**`AGENTS.md`** — removes the `## Project` milestone paragraph. It named issue #61 as "the current milestone" and pointed at the pre-migration baseline `main@8fa94b7`, so the next session would read it first and resume finished work. It is deleted rather than rewritten: AGENTS.md holds durable working guidance, and any restated status would go stale the same way. The file now carries no issue, PR, or commit references outside the Safety rule that mentions them as a policy. Every architecture constraint, data-boundary rule, tooling note, and verification gate is untouched.

**Spec README** — moves from `SPEC_READY` to `completed` and records the issue, the pull request, the merge commit, and the implementation head. Migration status belongs here and on issue #61, not in AGENTS.md.

No production code, test, or configuration changes.
