### PR TITLE
Add the shared section shell and a global page width

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,7 +7,10 @@ import { SiteHeader } from "@/components/site-header/site-header";
 import { ShopifyCartRuntime } from "@/lib/cart/shopify-cart-react";
 import { cn } from "@/lib/cn";
 import { storefrontRuntimeMode } from "@/lib/storefront/data-source";
-import { weaverseProjectId } from "@/lib/weaverse/server";
+import {
+  loadWeaverseThemeSettings,
+  weaverseProjectId,
+} from "@/lib/weaverse/server";
 import { StudioConnect } from "@/lib/weaverse/studio-connect";
 
 import "./globals.css";
@@ -48,9 +51,32 @@ export const viewport: Viewport = {
   themeColor: "#11130f",
 };
 
-export default function RootLayout({ children }: { children: ReactNode }) {
+/**
+ * Reads the merchant's page measure, or `null` to keep the theme's own.
+ *
+ * This is the first theme setting the storefront actually consumes. It lands
+ * as a CSS variable rather than a prop because `max-w-page` is a Tailwind
+ * token every section already resolves through.
+ */
+async function pageWidthStyle(): Promise<string | null> {
+  const theme = await loadWeaverseThemeSettings();
+  const pageWidth = (
+    theme?.themeSettings as { pageWidth?: unknown } | undefined
+  )?.pageWidth;
+  if (typeof pageWidth !== "number" || pageWidth <= 0) {
+    return null;
+  }
+  return `:root{--container-page:${pageWidth}px}`;
+}
+
+export default async function RootLayout({
+  children,
+}: {
+  children: ReactNode;
+}) {
   const shopifyCartEnabled = storefrontRuntimeMode === "shopify";
   const weaverseEnabled = weaverseProjectId() !== null;
+  const pageWidth = await pageWidthStyle();
   return (
     <html
       lang="en"
@@ -62,6 +88,12 @@ export default function RootLayout({ children }: { children: ReactNode }) {
       )}
     >
       <head>
+        {pageWidth === null ? null : (
+          <style
+            // biome-ignore lint/security/noDangerouslySetInnerHtml: one numeric theme setting rendered into a single custom property, never merchant markup.
+            dangerouslySetInnerHTML={{ __html: pageWidth }}
+          />
+        )}
         {shopifyCartEnabled ? (
           <script
             crossOrigin="anonymous"

--- a/src/components/section/index.tsx
+++ b/src/components/section/index.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { cva, type VariantProps } from "class-variance-authority";
+import Image from "next/image";
+import type { ElementType, ReactNode } from "react";
+
+import { cn } from "@/lib/cn";
+import type { StorefrontImage } from "@/lib/storefront/types";
+import { weaverseImage } from "@/lib/weaverse/image";
+import {
+  elementAttributes,
+  type WeaverseElementProps,
+} from "@/sections/weaverse-element";
+
+/**
+ * Two recipes, not one with two call sites: cva fills in `defaultVariants` for
+ * every variant a call omits, so a single recipe would put the width classes
+ * on the outer element as well and drop the gutter.
+ */
+const outerVariants = cva("relative", {
+  variants: {
+    width: { full: "", stretch: "", fixed: "" },
+  },
+  defaultVariants: { width: "fixed" },
+});
+
+/**
+ * The measure itself stays with the gutter, the way `SHELL_SECTION_CLASS`
+ * composed it, so converting a section does not move its content edge.
+ */
+const innerVariants = cva("relative", {
+  variants: {
+    width: {
+      full: "w-full",
+      stretch: "w-full px-page-gutter",
+      fixed: "mx-auto w-full max-w-page px-page-gutter",
+    },
+    verticalPadding: {
+      none: "",
+      compact: "py-section-block-compact",
+      default: "py-section-block",
+    },
+  },
+  defaultVariants: {
+    width: "fixed",
+    verticalPadding: "default",
+  },
+});
+
+export interface SectionProps
+  extends VariantProps<typeof innerVariants>,
+    WeaverseElementProps {
+  as?: ElementType;
+  /** Space between direct children, in px. */
+  gap?: number;
+  backgroundFor?: "section" | "content";
+  backgroundColor?: string;
+  /** A Builder image value, a StorefrontImage, or nothing. */
+  backgroundImage?: StorefrontImage | unknown;
+  backgroundFit?: "cover" | "contain";
+  enableOverlay?: boolean;
+  overlayColor?: string;
+  overlayOpacity?: number;
+  containerClassName?: string;
+  "aria-labelledby"?: string;
+  children?: ReactNode;
+}
+
+/**
+ * The shell every composed section renders inside.
+ *
+ * Width, padding, background, and overlay are the settings almost every
+ * section wants, so they are declared once here and spread into a schema from
+ * `./inputs`. Sections that hardcoded `SHELL_SECTION_CLASS` got the same
+ * measure with none of it editable; going through this component is what lets
+ * a merchant change the page measure globally and override it per section.
+ */
+export function Section({
+  as: Component = "section",
+  backgroundColor,
+  backgroundFit = "cover",
+  backgroundFor = "section",
+  backgroundImage,
+  children,
+  className,
+  containerClassName,
+  enableOverlay,
+  gap,
+  overlayColor = "#000000",
+  overlayOpacity = 50,
+  verticalPadding,
+  width,
+  ...rest
+}: SectionProps) {
+  const image = weaverseImage(backgroundImage);
+  const onContent = backgroundFor === "content";
+  const dressing = (
+    <>
+      {image === null ? null : (
+        <Image
+          alt={image.alt}
+          className={cn(
+            "absolute inset-0 h-full w-full",
+            backgroundFit === "contain" ? "object-contain" : "object-cover",
+          )}
+          height={image.height}
+          sizes="100vw"
+          src={image.src}
+          width={image.width}
+        />
+      )}
+      {enableOverlay === true && (
+        <div
+          aria-hidden="true"
+          className="absolute inset-0"
+          style={{
+            backgroundColor: overlayColor,
+            opacity: overlayOpacity / 100,
+          }}
+        />
+      )}
+    </>
+  );
+
+  return (
+    <Component
+      {...elementAttributes(rest)}
+      className={cn(outerVariants({ width }), className)}
+      style={onContent ? undefined : { backgroundColor }}
+    >
+      {onContent ? null : dressing}
+      <div
+        className={cn(
+          innerVariants({ verticalPadding, width }),
+          containerClassName,
+        )}
+        style={{
+          ...(onContent ? { backgroundColor } : undefined),
+          ...(gap === undefined ? undefined : { gap: `${gap}px` }),
+          ...(gap === undefined
+            ? undefined
+            : { display: "flex", flexDirection: "column" }),
+        }}
+      >
+        {onContent ? dressing : null}
+        {children}
+      </div>
+    </Component>
+  );
+}

--- a/src/components/section/inputs.ts
+++ b/src/components/section/inputs.ts
@@ -1,0 +1,96 @@
+/**
+ * The settings every section shares.
+ *
+ * A section schema spreads these rather than restating them, so "content
+ * width", "vertical padding", and the background controls mean the same thing
+ * everywhere and a merchant learns them once. Exported as plain data so a
+ * schema module stays importable outside Next.
+ */
+
+import type { InspectorGroup } from "@weaverse/schema";
+
+type SectionInputs = InspectorGroup["inputs"];
+
+/** Layout: how wide the section runs and how much air it gets. */
+export const layoutInputs: SectionInputs = [
+  {
+    type: "select",
+    name: "width",
+    label: "Content width",
+    configs: {
+      options: [
+        { value: "full", label: "Full page" },
+        { value: "stretch", label: "Stretch" },
+        { value: "fixed", label: "Fixed" },
+      ],
+    },
+  },
+  {
+    type: "range",
+    name: "gap",
+    label: "Items spacing",
+    configs: { min: 0, max: 60, step: 4, unit: "px" },
+  },
+  {
+    type: "select",
+    name: "verticalPadding",
+    label: "Vertical padding",
+    configs: {
+      options: [
+        { value: "none", label: "None" },
+        { value: "compact", label: "Compact" },
+        { value: "default", label: "Default" },
+      ],
+    },
+  },
+];
+
+/** Background: a flat colour, optionally behind an image. */
+export const backgroundInputs: SectionInputs = [
+  {
+    type: "select",
+    name: "backgroundFor",
+    label: "Background for",
+    configs: {
+      options: [
+        { value: "section", label: "Full section" },
+        { value: "content", label: "Content only" },
+      ],
+    },
+  },
+  { type: "color", name: "backgroundColor", label: "Background colour" },
+  { type: "image", name: "backgroundImage", label: "Background image" },
+  {
+    type: "select",
+    name: "backgroundFit",
+    label: "Image fit",
+    configs: {
+      options: [
+        { value: "cover", label: "Cover" },
+        { value: "contain", label: "Contain" },
+      ],
+    },
+  },
+];
+
+/**
+ * Overlay: only meaningful over a background image, which is why it is a
+ * separate group a section can leave out.
+ */
+export const overlayInputs: SectionInputs = [
+  { type: "switch", name: "enableOverlay", label: "Enable overlay" },
+  { type: "color", name: "overlayColor", label: "Overlay colour" },
+  {
+    type: "range",
+    name: "overlayOpacity",
+    label: "Overlay opacity",
+    configs: { min: 0, max: 100, step: 5, unit: "%" },
+  },
+];
+
+/** The three groups a section normally declares before its own content. */
+export const sectionSettings: InspectorGroup[] = [
+  { group: "Layout", inputs: layoutInputs },
+  { group: "Background", inputs: backgroundInputs },
+  { group: "Overlay", inputs: overlayInputs },
+];

--- a/src/lib/weaverse/server.ts
+++ b/src/lib/weaverse/server.ts
@@ -32,7 +32,6 @@ import { hasAuthoredSections } from "./page-payload";
 import {
   buildRequestContext,
   type SearchParams,
-  toSearchParams,
   type WeaversePageType,
 } from "./request-info";
 import { WEAVERSE_SERVER_COMPONENTS } from "./server-components";

--- a/src/lib/weaverse/settings/layout.ts
+++ b/src/lib/weaverse/settings/layout.ts
@@ -1,0 +1,21 @@
+import type { WeaverseNextThemeSchemaGroup } from "@weaverse/next";
+
+/**
+ * Global layout.
+ *
+ * `pageWidth` is the measure every `fixed`-width section is centred inside. It
+ * is a theme setting rather than a per-section one because a storefront reads
+ * as one page: sections disagreeing about their measure is the visual bug this
+ * prevents.
+ */
+export const layoutSettings = {
+  group: "Layout",
+  inputs: [
+    {
+      type: "range",
+      name: "pageWidth",
+      label: "Page width",
+      configs: { min: 1000, max: 1800, step: 20, unit: "px" },
+    },
+  ],
+} as const satisfies WeaverseNextThemeSchemaGroup;

--- a/src/lib/weaverse/settings/types.ts
+++ b/src/lib/weaverse/settings/types.ts
@@ -11,6 +11,7 @@
 import type { editorialImagerySettings } from "./editorial-imagery";
 import type { footerSettings } from "./footer";
 import type { headerSettings } from "./header";
+import type { layoutSettings } from "./layout";
 
 /** A Weaverse image value as it arrives from Builder. */
 export interface WeaverseImageValue {
@@ -61,6 +62,7 @@ type SettingsFromInputs<T extends readonly unknown[]> = {
 export type ExtractSettings<T extends { inputs: readonly unknown[] }> =
   SettingsFromInputs<T["inputs"]>;
 
+export type LayoutSettings = ExtractSettings<typeof layoutSettings>;
 export type HeaderSettings = ExtractSettings<typeof headerSettings>;
 export type FooterSettings = ExtractSettings<typeof footerSettings>;
 export type EditorialImagerySettings = ExtractSettings<
@@ -68,6 +70,7 @@ export type EditorialImagerySettings = ExtractSettings<
 >;
 
 /** Every theme setting this theme declares. */
-export type ThemeSettings = HeaderSettings &
+export type ThemeSettings = LayoutSettings &
+  HeaderSettings &
   FooterSettings &
   EditorialImagerySettings;

--- a/src/lib/weaverse/theme-schema.ts
+++ b/src/lib/weaverse/theme-schema.ts
@@ -15,13 +15,19 @@ import type { WeaverseNextThemeSchema } from "@weaverse/next";
 import { editorialImagerySettings } from "./settings/editorial-imagery";
 import { footerSettings } from "./settings/footer";
 import { headerSettings } from "./settings/header";
+import { layoutSettings } from "./settings/layout";
 
 export const themeSchema: WeaverseNextThemeSchema = {
   info: {
     name: "Forward",
     version: "0.1.0",
   },
-  settings: [headerSettings, footerSettings, editorialImagerySettings],
+  settings: [
+    layoutSettings,
+    headerSettings,
+    footerSettings,
+    editorialImagerySettings,
+  ],
 };
 
 export type {

--- a/src/sections/featured-products/index.tsx
+++ b/src/sections/featured-products/index.tsx
@@ -2,17 +2,10 @@
 
 import Link from "next/link";
 import { ProductCard } from "@/components/product-card";
-import {
-  eyebrow,
-  SHELL_SECTION_CLASS,
-  sectionHeading,
-  textLink,
-} from "@/lib/presentation/variants";
+import { Section } from "@/components/section";
+import { eyebrow, sectionHeading, textLink } from "@/lib/presentation/variants";
 import type { Product } from "@/lib/storefront/types";
-import {
-  elementAttributes,
-  type WeaverseElementProps,
-} from "../weaverse-element";
+import type { WeaverseElementProps } from "../weaverse-element";
 
 interface FeaturedProductsProps extends WeaverseElementProps {
   eyebrowLabel: string;
@@ -36,11 +29,7 @@ function FeaturedProducts({
 }: FeaturedProductsProps) {
   const products = loaderData?.products ?? [];
   return (
-    <section
-      {...elementAttributes(rest)}
-      aria-labelledby="home-featured-title"
-      className={SHELL_SECTION_CLASS}
-    >
+    <Section {...rest} aria-labelledby="home-featured-title">
       <header className="mb-11.25 grid grid-cols-feature-row items-end gap-10 max-md:grid-cols-1 max-md:gap-5">
         <div>
           <p className={eyebrow()}>{eyebrowLabel}</p>
@@ -62,7 +51,7 @@ function FeaturedProducts({
           />
         ))}
       </div>
-    </section>
+    </Section>
   );
 }
 

--- a/src/sections/featured-products/schema.ts
+++ b/src/sections/featured-products/schema.ts
@@ -1,9 +1,12 @@
 import { createSchema } from "@weaverse/schema";
 
+import { layoutInputs } from "@/components/section/inputs";
+
 export const schema = createSchema({
   type: "featured-products",
   title: "Featured products",
   settings: [
+    { group: "Layout", inputs: layoutInputs },
     {
       group: "Content",
       inputs: [

--- a/src/sections/field-practice/index.tsx
+++ b/src/sections/field-practice/index.tsx
@@ -1,16 +1,9 @@
 "use client";
 
 import Link from "next/link";
-import {
-  eyebrow,
-  SHELL_SECTION_CLASS,
-  sectionHeading,
-  textLink,
-} from "@/lib/presentation/variants";
-import {
-  elementAttributes,
-  type WeaverseElementProps,
-} from "../weaverse-element";
+import { Section } from "@/components/section";
+import { eyebrow, sectionHeading, textLink } from "@/lib/presentation/variants";
+import type { WeaverseElementProps } from "../weaverse-element";
 
 interface FieldPracticeProps extends WeaverseElementProps {
   eyebrowLabel: string;
@@ -30,7 +23,7 @@ function FieldPractice({
   ...rest
 }: FieldPracticeProps) {
   return (
-    <section {...elementAttributes(rest)} className={SHELL_SECTION_CLASS}>
+    <Section {...rest}>
       <div className="grid grid-cols-split-85 items-start gap-page-gap max-md:grid-cols-1">
         <div>
           <p className={eyebrow()}>{eyebrowLabel}</p>
@@ -45,7 +38,7 @@ function FieldPractice({
           </Link>
         </div>
       </div>
-    </section>
+    </Section>
   );
 }
 

--- a/src/sections/field-practice/schema.ts
+++ b/src/sections/field-practice/schema.ts
@@ -1,9 +1,12 @@
 import { createSchema } from "@weaverse/schema";
 
+import { layoutInputs } from "@/components/section/inputs";
+
 export const schema = createSchema({
   type: "field-practice",
   title: "Field practice",
   settings: [
+    { group: "Layout", inputs: layoutInputs },
     {
       group: "Content",
       inputs: [

--- a/src/sections/kit-callout/index.tsx
+++ b/src/sections/kit-callout/index.tsx
@@ -2,10 +2,10 @@
 
 import Image from "next/image";
 import Link from "next/link";
+import { Section } from "@/components/section";
 import { cn } from "@/lib/cn";
 import {
   eyebrow,
-  SHELL_SECTION_CLASS,
   sectionHeading,
   textLink,
   VIEWPORT_SECTION_CLASS,
@@ -52,10 +52,10 @@ function KitCallout({
     );
   }
   return (
-    <section
-      {...elementAttributes(rest)}
-      className={cn(
-        SHELL_SECTION_CLASS,
+    <Section
+      {...rest}
+      verticalPadding="none"
+      containerClassName={cn(
         "grid grid-cols-[0.55fr_1.45fr] items-end gap-15 max-md:grid-cols-1",
         VIEWPORT_SECTION_CLASS,
       )}
@@ -88,7 +88,7 @@ function KitCallout({
           </Link>
         ))}
       </div>
-    </section>
+    </Section>
   );
 }
 

--- a/src/sections/kit-callout/schema.ts
+++ b/src/sections/kit-callout/schema.ts
@@ -1,9 +1,12 @@
 import { createSchema } from "@weaverse/schema";
 
+import { layoutInputs } from "@/components/section/inputs";
+
 export const schema = createSchema({
   type: "kit-callout",
   title: "Kit callout",
   settings: [
+    { group: "Layout", inputs: layoutInputs },
     {
       group: "Content",
       inputs: [

--- a/src/sections/page-origin/index.tsx
+++ b/src/sections/page-origin/index.tsx
@@ -2,19 +2,11 @@
 
 import Image from "next/image";
 import Link from "next/link";
-
-import {
-  eyebrow,
-  SHELL_SECTION_CLASS,
-  sectionHeading,
-  textLink,
-} from "@/lib/presentation/variants";
+import { Section } from "@/components/section";
+import { eyebrow, sectionHeading, textLink } from "@/lib/presentation/variants";
 import type { StorefrontImage } from "@/lib/storefront/types";
 import { weaverseImage } from "@/lib/weaverse/image";
-import {
-  elementAttributes,
-  type WeaverseElementProps,
-} from "../weaverse-element";
+import type { WeaverseElementProps } from "../weaverse-element";
 
 interface PageOriginProps extends WeaverseElementProps {
   eyebrowLabel: string;
@@ -38,7 +30,7 @@ function PageOrigin({
 }: PageOriginProps) {
   const resolvedImage = weaverseImage(image);
   return (
-    <section {...elementAttributes(rest)} className={SHELL_SECTION_CLASS}>
+    <Section {...rest}>
       <div className="grid grid-cols-split-75 items-start gap-20 max-md:grid-cols-1">
         <div>
           <p className={eyebrow()}>{eyebrowLabel}</p>
@@ -66,7 +58,7 @@ function PageOrigin({
           </Link>
         </div>
       </div>
-    </section>
+    </Section>
   );
 }
 

--- a/src/sections/page-origin/schema.ts
+++ b/src/sections/page-origin/schema.ts
@@ -1,9 +1,12 @@
 import { createSchema } from "@weaverse/schema";
 
+import { layoutInputs } from "@/components/section/inputs";
+
 export const schema = createSchema({
   type: "page-origin",
   title: "Page origin",
   settings: [
+    { group: "Layout", inputs: layoutInputs },
     {
       group: "Content",
       inputs: [

--- a/src/sections/page-premise/index.tsx
+++ b/src/sections/page-premise/index.tsx
@@ -4,16 +4,10 @@ import {
   RichTextParagraph,
   richTextParagraphKey,
 } from "@/components/rich-text-paragraph";
-import {
-  eyebrow,
-  SHELL_SECTION_CLASS,
-  sectionHeading,
-} from "@/lib/presentation/variants";
+import { Section } from "@/components/section";
+import { eyebrow, sectionHeading } from "@/lib/presentation/variants";
 import { useStorefrontContext } from "@/lib/weaverse/data-context";
-import {
-  elementAttributes,
-  type WeaverseElementProps,
-} from "../weaverse-element";
+import type { WeaverseElementProps } from "../weaverse-element";
 
 interface PagePremiseProps extends WeaverseElementProps {
   eyebrowLabel: string;
@@ -30,7 +24,7 @@ function PagePremise({ eyebrowLabel, ...rest }: PagePremiseProps) {
   if (page === undefined) return null;
   const premise = page.sections[0];
   return (
-    <section {...elementAttributes(rest)} className={SHELL_SECTION_CLASS}>
+    <Section {...rest}>
       <div className="grid grid-cols-split-85 items-start gap-page-gap max-md:grid-cols-1">
         <div>
           <p className={eyebrow()}>{eyebrowLabel}</p>
@@ -52,7 +46,7 @@ function PagePremise({ eyebrowLabel, ...rest }: PagePremiseProps) {
           ))}
         </div>
       </div>
-    </section>
+    </Section>
   );
 }
 

--- a/src/sections/page-premise/schema.ts
+++ b/src/sections/page-premise/schema.ts
@@ -1,9 +1,12 @@
 import { createSchema } from "@weaverse/schema";
 
+import { layoutInputs } from "@/components/section/inputs";
+
 export const schema = createSchema({
   type: "page-premise",
   title: "Page premise",
   settings: [
+    { group: "Layout", inputs: layoutInputs },
     {
       group: "Content",
       inputs: [

--- a/src/sections/product-spotlight/index.tsx
+++ b/src/sections/product-spotlight/index.tsx
@@ -2,12 +2,12 @@
 
 import Image from "next/image";
 import Link from "next/link";
+import { Section } from "@/components/section";
 import { cn } from "@/lib/cn";
 import {
   cta,
   eyebrow,
   LEDE_CLASS,
-  SHELL_SECTION_CLASS,
   sectionHeading,
   VIEWPORT_SECTION_CLASS,
 } from "@/lib/presentation/variants";
@@ -50,10 +50,10 @@ function ProductSpotlight({
   }
   const { image, product } = loaderData;
   return (
-    <section
-      {...elementAttributes(rest)}
-      className={cn(
-        SHELL_SECTION_CLASS,
+    <Section
+      {...rest}
+      verticalPadding="none"
+      containerClassName={cn(
         "grid grid-cols-[minmax(0,1.25fr)_minmax(380px,0.75fr)] gap-0 max-md:grid-cols-1",
         VIEWPORT_SECTION_CLASS,
       )}
@@ -109,7 +109,7 @@ function ProductSpotlight({
           {ctaLabel}
         </Link>
       </div>
-    </section>
+    </Section>
   );
 }
 

--- a/src/sections/product-spotlight/schema.ts
+++ b/src/sections/product-spotlight/schema.ts
@@ -1,9 +1,12 @@
 import { createSchema } from "@weaverse/schema";
 
+import { layoutInputs } from "@/components/section/inputs";
+
 export const schema = createSchema({
   type: "product-spotlight",
   title: "Product spotlight",
   settings: [
+    { group: "Layout", inputs: layoutInputs },
     {
       group: "Content",
       inputs: [

--- a/src/sections/related-products/index.tsx
+++ b/src/sections/related-products/index.tsx
@@ -1,16 +1,10 @@
 "use client";
 
 import { ProductCard } from "@/components/product-card";
-import {
-  eyebrow,
-  SHELL_SECTION_CLASS,
-  sectionHeading,
-} from "@/lib/presentation/variants";
+import { Section } from "@/components/section";
+import { eyebrow, sectionHeading } from "@/lib/presentation/variants";
 import { useStorefrontContext } from "@/lib/weaverse/data-context";
-import {
-  elementAttributes,
-  type WeaverseElementProps,
-} from "../weaverse-element";
+import type { WeaverseElementProps } from "../weaverse-element";
 
 interface RelatedProductsProps extends WeaverseElementProps {
   eyebrowLabel: string;
@@ -26,7 +20,7 @@ function RelatedProducts({
   const { products: contextProducts } = useStorefrontContext();
   const products = contextProducts ?? [];
   return (
-    <section {...elementAttributes(rest)} className={SHELL_SECTION_CLASS}>
+    <Section {...rest}>
       <div className="mb-11 flex items-end justify-between gap-7.5 max-sm:flex-col max-sm:items-start">
         <div>
           <p className={eyebrow()}>{eyebrowLabel}</p>
@@ -38,7 +32,7 @@ function RelatedProducts({
           <ProductCard key={product.handle} product={product} />
         ))}
       </div>
-    </section>
+    </Section>
   );
 }
 

--- a/src/sections/related-products/schema.ts
+++ b/src/sections/related-products/schema.ts
@@ -1,9 +1,12 @@
 import { createSchema } from "@weaverse/schema";
 
+import { layoutInputs } from "@/components/section/inputs";
+
 export const schema = createSchema({
   type: "related-products",
   title: "Related products",
   settings: [
+    { group: "Layout", inputs: layoutInputs },
     {
       group: "Content",
       inputs: [

--- a/src/sections/repair-and-journal/index.tsx
+++ b/src/sections/repair-and-journal/index.tsx
@@ -2,17 +2,10 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import { cn } from "@/lib/cn";
-import {
-  eyebrow,
-  SHELL_SECTION_CLASS,
-  textLink,
-} from "@/lib/presentation/variants";
+import { Section } from "@/components/section";
+import { eyebrow, textLink } from "@/lib/presentation/variants";
 import type { JournalArticle } from "@/lib/storefront/types";
-import {
-  elementAttributes,
-  type WeaverseElementProps,
-} from "../weaverse-element";
+import type { WeaverseElementProps } from "../weaverse-element";
 
 interface RepairAndJournalProps extends WeaverseElementProps {
   repairEyebrowLabel: string;
@@ -40,12 +33,9 @@ function RepairAndJournal({
 }: RepairAndJournalProps) {
   const article = loaderData?.article ?? undefined;
   return (
-    <section
-      {...elementAttributes(rest)}
-      className={cn(
-        SHELL_SECTION_CLASS,
-        "grid grid-cols-split-70 gap-3 max-md:grid-cols-1",
-      )}
+    <Section
+      {...rest}
+      containerClassName="grid grid-cols-split-70 gap-3 max-md:grid-cols-1"
     >
       <article className="min-h-140 bg-signal p-[clamp(35px,5vw,70px)] max-md:min-h-0">
         <p className={eyebrow()}>{repairEyebrowLabel}</p>
@@ -79,7 +69,7 @@ function RepairAndJournal({
           </div>
         </article>
       ) : null}
-    </section>
+    </Section>
   );
 }
 

--- a/src/sections/repair-and-journal/schema.ts
+++ b/src/sections/repair-and-journal/schema.ts
@@ -1,9 +1,12 @@
 import { createSchema } from "@weaverse/schema";
 
+import { layoutInputs } from "@/components/section/inputs";
+
 export const schema = createSchema({
   type: "repair-and-journal",
   title: "Repair and journal",
   settings: [
+    { group: "Layout", inputs: layoutInputs },
     {
       group: "Content",
       inputs: [

--- a/src/sections/system-manifest/index.tsx
+++ b/src/sections/system-manifest/index.tsx
@@ -2,19 +2,12 @@
 
 import Image from "next/image";
 import Link from "next/link";
-
-import {
-  eyebrow,
-  SHELL_SECTION_CLASS,
-  textLink,
-} from "@/lib/presentation/variants";
+import { Section } from "@/components/section";
+import { eyebrow, textLink } from "@/lib/presentation/variants";
 import type { StorefrontImage } from "@/lib/storefront/types";
 import { useStorefrontContext } from "@/lib/weaverse/data-context";
 import { weaverseImage } from "@/lib/weaverse/image";
-import {
-  elementAttributes,
-  type WeaverseElementProps,
-} from "../weaverse-element";
+import type { WeaverseElementProps } from "../weaverse-element";
 
 interface SystemManifestProps extends WeaverseElementProps {
   eyebrowLabel: string;
@@ -41,7 +34,7 @@ function SystemManifest({
   const products = collectionProducts ?? [];
   const resolvedImage = weaverseImage(image);
   return (
-    <section {...elementAttributes(rest)} className={SHELL_SECTION_CLASS}>
+    <Section {...rest}>
       <div className="grid grid-cols-[0.8fr_1.2fr] items-center gap-[clamp(50px,10vw,150px)] max-md:grid-cols-1">
         {resolvedImage === null ? null : (
           <div className="translate-y-20 shadow-collection-feature max-md:translate-y-0 max-md:shadow-collection-feature-mobile">
@@ -82,7 +75,7 @@ function SystemManifest({
           ) : null}
         </div>
       </div>
-    </section>
+    </Section>
   );
 }
 

--- a/src/sections/system-manifest/schema.ts
+++ b/src/sections/system-manifest/schema.ts
@@ -1,9 +1,12 @@
 import { createSchema } from "@weaverse/schema";
 
+import { layoutInputs } from "@/components/section/inputs";
+
 export const schema = createSchema({
   type: "system-manifest",
   title: "System manifest",
   settings: [
+    { group: "Layout", inputs: layoutInputs },
     {
       group: "Content",
       inputs: [

--- a/src/sections/weaverse-element.ts
+++ b/src/sections/weaverse-element.ts
@@ -26,13 +26,22 @@ export interface WeaverseElementProps {
  *
  * The runtime's prop bag also carries authored settings, which are not DOM
  * attributes; passing those to React logs unknown-prop warnings. Only the
- * identity attributes and `id` are forwarded.
+ * identity attributes, `id`, and any `aria-*` a component passes through are
+ * forwarded — an ARIA attribute is never an authored setting, and dropping one
+ * silently removes the accessible name a section was labelled by.
  */
 export function elementAttributes(
   props: WeaverseElementProps,
 ): Record<string, string> {
   const attributes: Record<string, string> = {};
-  for (const key of ["data-wv-id", "data-wv-type", "id"] as const) {
+  const forwarded = Object.keys(props).filter(
+    (key) =>
+      key === "data-wv-id" ||
+      key === "data-wv-type" ||
+      key === "id" ||
+      key.startsWith("aria-"),
+  );
+  for (const key of forwarded) {
     const value = props[key];
     if (typeof value === "string" && value.length > 0) {
       attributes[key] = value;

--- a/tests/dom/composed-sections.test.tsx
+++ b/tests/dom/composed-sections.test.tsx
@@ -12,6 +12,7 @@ import {
   StorefrontDataProvider,
 } from "@/lib/weaverse/data-context";
 import EditorialHero from "@/sections/editorial-hero";
+import { elementAttributes } from "@/sections/weaverse-element";
 
 /**
  * Every component a merchant can place in Studio, taken from the registry
@@ -91,6 +92,27 @@ describe("image inputs survive Builder's own shape", () => {
 
     assert.equal(container.querySelector("img"), null);
     assert.ok(container.textContent?.includes("Heading"));
+  });
+});
+
+describe("element attributes", () => {
+  /* `aria-labelledby` on a section is its accessible name. The filter used to
+   * drop it, which removed the name silently — the storefront looked right and
+   * only a browser assertion noticed. */
+  it("forwards aria attributes as well as the Weaverse identity", () => {
+    assert.deepEqual(
+      elementAttributes({
+        "aria-labelledby": "title",
+        "data-wv-id": "item-1",
+        "data-wv-type": "featured-products",
+        heading: "not a DOM attribute",
+      }),
+      {
+        "aria-labelledby": "title",
+        "data-wv-id": "item-1",
+        "data-wv-type": "featured-products",
+      },
+    );
   });
 });
 


### PR DESCRIPTION
Slice 1 of #72, plus the spike that unblocked the rest of it.

## Spike: the runtime supports nesting

Before building anything, a throwaway section declaring `childTypes: ["heading", "paragraph"]` was written to a `CUSTOM` page as a three-level item tree. It rendered as:

```
<div>      type=main          ← page root
<section>  type=spike-stack   ← parent, children prop present
  <h2>     type=heading       ← child, own data-wv-id
  <p>      type=paragraph     ← child, own data-wv-id
```

`@weaverse/next` passes `children` to a Client Component section, each child keeps its own identity, and select / drag-reorder / add-child all work in the editor. Nothing in #72 is blocked on the SDK. The spike is removed.

## What this PR does

Every section wrote its own page-width shell, so the measure, the gutter and the vertical rhythm were fixed in each file and none of it was editable.

- `src/components/section/` holds that shell once and exports `layoutInputs`, `backgroundInputs`, `overlayInputs` for a schema to declare.
- `pageWidth` becomes a theme setting, and the root layout **reads theme settings for the first time**, emitting `--container-page`. That closes the "theme settings are declared but nothing reads them" gap carried since #67.
- The nine sections that used `SHELL_SECTION_CLASS` verbatim now render through it and declare `layoutInputs`.

## Two real defects found on the way

**cva defaults leaked onto the outer element.** One recipe called twice put the width classes on both elements and dropped `px-page-gutter` — content ran to the viewport edge. Split into `outerVariants` / `innerVariants`. The inner class is now byte-identical to the old `SHELL_SECTION_CLASS`, so no content edge moves.

**`elementAttributes` swallowed `aria-labelledby`.** It forwarded only `data-wv-*` and `id`, so wrapping `featured-products` removed the section's accessible name. Three browser tests dropped from 4 matching cards to 0. It now forwards `aria-*` as well, with a DOM test pinning the behaviour.

Worth recording: typecheck, lint, 371 node tests, 131 DOM tests and `smoke:routes` were all green while that accessible name was gone. Only the browser matrix caught it.

## Not in this PR

`backgroundInputs` and `overlayInputs` are written and `Section` renders them, but no section declares them yet. Ten sections with bespoke layouts (`home-hero`, `collection-*`, `editorial-*`) are left for slice 4, where they are converted at the same time as their copy moves into children.

## Verification

```
bun run check               # 371 node + 132 DOM, build, theme, routes — green
bun run smoke:routes        # 35/35
bun run test:browser:static # 146 passed / 10 skipped / 0 failed
```
