### PR TITLE
Nest sections, compose the buy block, and reseed from presets

### DIFF
--- a/.weaverse/specs/2026-09-07--forward-weaverse-contract/work-logs.md
+++ b/.weaverse/specs/2026-09-07--forward-weaverse-contract/work-logs.md
@@ -876,3 +876,103 @@ Branch `feat/weaverse-page-types` from `main@0c84182`.
   placeholder for a handle that does not exist. Not worth a log that lies.
 - Gates after all of it: `check` 370 node + 131 DOM, `smoke:routes` 35/35,
   static browser matrix 146/0.
+
+## 2026-09-09 — Sections as composable containers (#72)
+
+Leo reviewed the composed sections and named three gaps, all of which held up:
+no shared `Section` wrapper, no nesting at all, and the shared elements
+(`heading`, `subheading`, `paragraph`, `button`) registered but used in **zero**
+sections. Reading Pilot confirmed the shape: 29 of its sections go through
+`app/components/section.tsx`, 34 of 79 schemas declare `childTypes`, and the
+elements live as children of content blocks.
+
+The root cause was one decision made during the extraction: sections were cut
+as **whole visual bands** — one component renders one finished band — where
+Pilot cuts them as **containers**. That is why every setting became a flat text
+input and why the four elements had nowhere to live.
+
+### Spike first
+
+A throwaway section declaring `childTypes: ["heading", "paragraph"]`, written to
+a `CUSTOM` page as a three-level tree, rendered `main` → `spike-stack` →
+`heading` + `paragraph`, each child keeping its own `data-wv-id`. Leo confirmed
+select, drag-reorder and add-child in Studio. Nothing was blocked on the SDK, so
+the whole plan was safe to start. The spike was removed afterwards; its page and
+items are still in the project because the Content API cannot delete them.
+
+### Slice 1 — the shared shell
+
+`src/components/section/` holds width, gutter, vertical rhythm, background and
+overlay once, and exports the inputs a schema declares. `pageWidth` became a
+theme setting and the root layout **reads theme settings for the first time**,
+emitting `--container-page` — which closes the "theme settings are declared but
+nothing reads them" gap carried since #67.
+
+- **cva defaults leaked onto the outer element.** One recipe called twice put
+  the width classes on both elements and dropped `px-page-gutter`; content ran
+  to the viewport edge. Split into `outerVariants` / `innerVariants`, and the
+  inner class is now byte-identical to the old `SHELL_SECTION_CLASS`, so no
+  content edge moved.
+- **`elementAttributes` swallowed `aria-labelledby`.** It forwarded only
+  `data-wv-*` and `id`, so wrapping `featured-products` removed the section's
+  accessible name and three browser tests went from 4 matching cards to 0. It
+  forwards `aria-*` now, with a DOM test pinning it. Worth recording: typecheck,
+  lint, 371 node tests, 131 DOM tests and `smoke:routes` were **all green**
+  while that name was gone. Only the browser matrix noticed.
+
+### Slice 2 — and the seed script came back, as a different thing
+
+`section-content` is the column that holds the shared elements. `button` gained
+a `link` intent rendering the underlined arrow link the sections already use —
+without it, converting a section would silently turn its text link into a call
+to action.
+
+Converting `field-practice` exposed the real obstacle: changing a section's
+shape strands the flat data its pages already hold, and the seed script had been
+deleted in #70. Migrating by hand meant a `curl` per section with ~19 to go, no
+way to remove the items left behind, and no fallback to catch a mistake. Leo
+chose to rebuild the script and reseed every page.
+
+The rebuilt script is not the old one. A seed file now says **only** which
+sections a page carries and in what order; the copy, the nested children and
+their settings expand from each schema's `presets`, recursively. A shape change
+is a `presets` edit plus a re-run. One bug on the first pass: `expand()` ignored
+a parent's preset children, so both columns of a two-column band expanded to the
+same generic default — the parent's children win now, and the child schema's own
+are the fallback for a column placed by hand.
+
+### Slice 3 — smaller than expected
+
+Checking first changed the size of it: `main-collection`, `main-article` and
+`main-page` **already existed** as sections. The PDP was the only main page
+content still rendering outside Weaverse.
+
+`main-product` wraps `ProductDetail` unchanged — gallery, colorway and size
+selection, price and the cart handoff own variant identity and query state and
+stay in code — and takes its product from the route context. That is the
+ownership rule Leo confirmed: *theme-owned means the logic lives in code, not
+that the surface is invisible to Studio*. The route went from 175 lines to 75,
+and all 146 browser assertions stayed green.
+
+### Slice 4 — and what was deliberately left alone
+
+`editorial-callout` became three content columns. Five more sections moved onto
+the shared shell with no markup change, gaining width and padding settings.
+
+Left flat on purpose: the full-bleed heroes (own grid and min-height),
+`article-body` (renders Shopify blocks verbatim), the data-driven lists (no
+editorial copy to lift), and the `standard-statement` statement itself, whose
+`text-about-statement` size the `heading` element cannot express. Converting the
+hero group needs more sizes on `heading` first, which touches the type scale and
+belongs to its own issue.
+
+The rule applied throughout: lift copy into children only where it is genuinely
+editorial **and** a shared element can express it. Converting the rest
+mechanically would have changed the design without giving a merchant anything.
+
+### Verification
+
+Every gate was re-run after **each** slice, not once at the end:
+`bun run check` 371 node + 136 DOM, `smoke:routes` 35/35, static browser matrix
+146/0. All eight seeded routes were checked for their real `h1` after each
+reseed.

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "check:theme": "node scripts/check-tailwind-theme.mts",
     "check:routes": "node scripts/check-routes.mts",
     "smoke:routes": "node scripts/smoke-routes.mts",
+    "seed:weaverse": "bun scripts/seed-weaverse.mts",
     "verify:shopify": "bun scripts/verify-shopify.mts",
     "verify:static": "bun scripts/verify-matrix.mts static",
     "verify:live": "bun scripts/verify-matrix.mts live",

--- a/scripts/seed-weaverse.mts
+++ b/scripts/seed-weaverse.mts
@@ -1,0 +1,353 @@
+/**
+ * Seeds the Weaverse project from the theme's own schemas.
+ *
+ * A seed file says which sections a page carries and in what order. Everything
+ * else — the copy, the nested children, their settings — is expanded from each
+ * schema's `presets`, recursively. That matters because sections are trees now:
+ * writing the tree out by hand would put the same sentence in two places again,
+ * and would go stale the moment a section changes shape.
+ *
+ * Re-running is the migration path. Item ids are derived from the page and the
+ * position in the tree, so a second run rewrites the same items and re-points
+ * the root at them. Items the new shape no longer uses are left detached — the
+ * Content API has no delete — so they stop rendering but stay in the project
+ * until someone removes them in Studio.
+ *
+ * Safety:
+ *
+ * - dry run by default; `--apply` is required to write anything;
+ * - every section type is checked against the registry before any request;
+ * - the API key is read from the environment and never logged or echoed.
+ *
+ * Usage:
+ *
+ *   bun run seed:weaverse            # dry run, prints the tree
+ *   bun run seed:weaverse --apply    # writes it
+ *
+ * Requires `WEAVERSE_PROJECT_ID` and, for `--apply`, `WEAVERSE_API_KEY`.
+ */
+
+import { createHash } from "node:crypto";
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+
+import { SECTION_SCHEMAS } from "../src/lib/weaverse/section-schemas.ts";
+
+const CONTENT_API_BASE = "https://studio.weaverse.io/api/v1/content";
+const SEED_DIR = path.join(import.meta.dirname, "weaverse-seed");
+/** The Content API caps a page update at 100 items. */
+const MAX_ITEMS_PER_REQUEST = 100;
+
+/**
+ * Stands in for a resource-backed template's handle in the request path.
+ *
+ * The Content API requires a handle segment for `PRODUCT`, `COLLECTION`,
+ * `PAGE`, and `ARTICLE` — omitting it answers `400 A handle is required` — but
+ * does not resolve by it: every handle returns the one shared default template.
+ */
+const TEMPLATE_HANDLE = "default";
+
+interface SeedSection {
+  type: string;
+  /** Settings that differ from the section's own `presets`. */
+  data?: Record<string, unknown>;
+}
+
+interface SeedPage {
+  pageType: string;
+  /** Empty for a resource-backed template; only a `CUSTOM` page has its own. */
+  handle: string;
+  name?: string;
+  description?: string;
+  sections: SeedSection[];
+}
+
+interface PageItem {
+  id: string;
+  type?: string;
+  data: Record<string, unknown>;
+  children?: { id: string }[];
+}
+
+function fail(message: string): never {
+  console.error(`seed:weaverse: ${message}`);
+  process.exit(1);
+}
+
+function pageRef(page: SeedPage): string {
+  return page.handle.length > 0
+    ? `${page.pageType}/${page.handle}`
+    : page.pageType;
+}
+
+function pagePath(page: SeedPage): string {
+  const handle = page.handle.length > 0 ? page.handle : TEMPLATE_HANDLE;
+  return `${page.pageType}/${handle}`;
+}
+
+const SCHEMA_BY_TYPE = new Map(SECTION_SCHEMAS.map((s) => [s.type, s]));
+
+/** A stable UUID-shaped id for one position in one page's tree. */
+function itemId(pageKey: string, treePath: string): string {
+  const digest = createHash("sha256")
+    .update(`forward:${pageKey}:${treePath}`)
+    .digest("hex");
+  return [
+    digest.slice(0, 8),
+    digest.slice(8, 12),
+    `7${digest.slice(13, 16)}`,
+    ((Number.parseInt(digest.slice(16, 17), 16) & 0x3) | 0x8).toString(16) +
+      digest.slice(17, 20),
+    digest.slice(20, 32),
+  ].join("-");
+}
+
+interface PresetChild {
+  type: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Expands one section, and everything under it, into flat items.
+ *
+ * A parent's `presets.children` wins over the child schema's own: a two-column
+ * band says what belongs in each column, and the column's generic preset is
+ * only the fallback for a column placed by hand in Studio.
+ */
+function expand(
+  pageKey: string,
+  treePath: string,
+  type: string,
+  overrides: Record<string, unknown>,
+  into: PageItem[],
+  childrenOverride?: PresetChild[],
+): string {
+  const schema = SCHEMA_BY_TYPE.get(type);
+  const { children: schemaChildren = [], ...presets } = (schema?.presets ??
+    {}) as {
+    children?: PresetChild[];
+  } & Record<string, unknown>;
+  const children = childrenOverride ?? schemaChildren;
+
+  const id = itemId(pageKey, treePath);
+  const childIds = children.map((child, index) => {
+    const {
+      type: childType,
+      children: grandchildren,
+      ...childOverrides
+    } = child as PresetChild & { children?: PresetChild[] };
+    return expand(
+      pageKey,
+      `${treePath}/${index}`,
+      childType,
+      childOverrides,
+      into,
+      grandchildren,
+    );
+  });
+
+  into.push({
+    id,
+    type,
+    data: { ...presets, ...overrides },
+    ...(childIds.length > 0
+      ? { children: childIds.map((childId) => ({ id: childId })) }
+      : {}),
+  });
+  return id;
+}
+
+function buildItems(page: SeedPage, rootId: string): PageItem[] {
+  const items: PageItem[] = [];
+  const sectionIds = page.sections.map((section, index) =>
+    expand(
+      pageRef(page),
+      `${index}-${section.type}`,
+      section.type,
+      section.data ?? {},
+      items,
+    ),
+  );
+  return [
+    { id: rootId, data: {}, children: sectionIds.map((id) => ({ id })) },
+    ...items,
+  ];
+}
+
+function validate(pages: SeedPage[]): void {
+  const problems: string[] = [];
+  const claimed = new Map<string, string>();
+
+  for (const page of pages) {
+    const ref = pageRef(page);
+    if (page.sections.length === 0) {
+      problems.push(`${ref}: no sections`);
+    }
+
+    const items = buildItems(page, "root-placeholder");
+    if (items.length > MAX_ITEMS_PER_REQUEST) {
+      problems.push(
+        `${ref}: ${items.length} items exceeds the ${MAX_ITEMS_PER_REQUEST}-item request cap`,
+      );
+    }
+    for (const item of items.slice(1)) {
+      if (item.type !== undefined && !SCHEMA_BY_TYPE.has(item.type)) {
+        problems.push(`${ref}: "${item.type}" is not a registered component`);
+      }
+      /* Item ids are keyed on the page handle, and every template shares the
+       * same empty one, so a collision across templates would write both to
+       * one item. */
+      const owner = claimed.get(item.id);
+      if (owner !== undefined && owner !== ref) {
+        problems.push(`${ref}: an item id collides with ${owner}`);
+      }
+      claimed.set(item.id, ref);
+    }
+  }
+
+  if (problems.length > 0) {
+    fail(`seed data is invalid:\n  - ${problems.join("\n  - ")}`);
+  }
+}
+
+async function request(
+  apiKey: string,
+  method: "POST" | "PATCH",
+  endpoint: string,
+  body: unknown,
+): Promise<{ ok: boolean; status: number }> {
+  const response = await fetch(`${CONTENT_API_BASE}${endpoint}`, {
+    method,
+    headers: {
+      authorization: `Bearer ${apiKey}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+  /* The response can echo the request, so only the status is ever read. */
+  return { ok: response.ok, status: response.status };
+}
+
+/** Reads the id of the root item the Builder created for this page. */
+async function fetchRootId(
+  apiKey: string,
+  projectId: string,
+  page: SeedPage,
+): Promise<string> {
+  const response = await fetch(
+    `${CONTENT_API_BASE}/projects/${projectId}/pages/${pagePath(page)}`,
+    { headers: { authorization: `Bearer ${apiKey}` } },
+  );
+  if (!response.ok) {
+    fail(`reading ${pageRef(page)} responded ${response.status}`);
+  }
+  const body = (await response.json()) as {
+    rootId?: string;
+    items?: { id: string; type?: string }[];
+  };
+  const rootId =
+    body.rootId ??
+    body.items?.find((item) => item.type === "main" || item.type === "root")
+      ?.id;
+  if (typeof rootId !== "string" || rootId.length === 0) {
+    fail(`${pageRef(page)} has no root item to attach to`);
+  }
+  return rootId;
+}
+
+async function seedPage(
+  apiKey: string,
+  projectId: string,
+  page: SeedPage,
+): Promise<void> {
+  /* A template already exists — the Builder creates one per page type with the
+   * project — so only a CUSTOM page is ever created here. */
+  if (page.handle.length > 0) {
+    const created = await request(
+      apiKey,
+      "POST",
+      `/projects/${projectId}/pages`,
+      {
+        type: page.pageType,
+        handle: page.handle,
+        name: page.name ?? page.handle,
+      },
+    );
+    if (!created.ok && created.status !== 409) {
+      fail(`creating ${pageRef(page)} responded ${created.status}`);
+    }
+  }
+
+  const rootId = await fetchRootId(apiKey, projectId, page);
+  const items = buildItems(page, rootId);
+  const updated = await request(
+    apiKey,
+    "PATCH",
+    `/projects/${projectId}/pages/${pagePath(page)}`,
+    { items },
+  );
+  if (!updated.ok) {
+    fail(`updating ${pageRef(page)} responded ${updated.status}`);
+  }
+  console.log(`  wrote ${pageRef(page)} (${items.length} items)`);
+}
+
+function describe(page: SeedPage): void {
+  const items = buildItems(page, "root");
+  console.log(`  ${pageRef(page)}: ${items.length} items`);
+  const byId = new Map(items.map((item) => [item.id, item]));
+  const walk = (id: string, depth: number) => {
+    const item = byId.get(id);
+    if (item === undefined) return;
+    if (depth > 0) {
+      console.log(`  ${"  ".repeat(depth)}- ${item.type}`);
+    }
+    for (const child of item.children ?? []) walk(child.id, depth + 1);
+  };
+  walk("root", 0);
+}
+
+async function main(): Promise<void> {
+  const apply = process.argv.includes("--apply");
+  const projectId = process.env.WEAVERSE_PROJECT_ID?.trim();
+  if (projectId === undefined || projectId.length === 0) {
+    fail("WEAVERSE_PROJECT_ID is not configured.");
+  }
+
+  const files = (await readdir(SEED_DIR))
+    .filter((file) => file.endsWith(".json"))
+    .sort();
+  const pages: SeedPage[] = [];
+  for (const file of files) {
+    const source = await readFile(path.join(SEED_DIR, file), "utf8");
+    try {
+      pages.push(JSON.parse(source) as SeedPage);
+    } catch (error) {
+      fail(`${file} is not valid JSON: ${(error as Error).message}`);
+    }
+  }
+
+  validate(pages);
+
+  console.log(
+    `seed:weaverse: ${apply ? "APPLYING to" : "dry run against"} project ${projectId}`,
+  );
+  for (const page of pages) describe(page);
+
+  if (!apply) {
+    console.log(
+      "seed:weaverse: dry run complete. Nothing was written. Re-run with --apply.",
+    );
+    return;
+  }
+
+  const apiKey = process.env.WEAVERSE_API_KEY?.trim();
+  if (apiKey === undefined || apiKey.length === 0) {
+    fail("WEAVERSE_API_KEY is required for --apply.");
+  }
+  for (const page of pages) await seedPage(apiKey, projectId, page);
+  console.log("seed:weaverse: done.");
+}
+
+await main();

--- a/scripts/weaverse-seed/page-about.json
+++ b/scripts/weaverse-seed/page-about.json
@@ -1,0 +1,34 @@
+{
+  "pageType": "CUSTOM",
+  "handle": "about",
+  "name": "About Forward",
+  "sections": [
+    {
+      "type": "editorial-hero",
+      "data": {
+        "eyebrowLabel": "Custom page / About Forward",
+        "heading": "Make less equipment. Make every piece matter.",
+        "lede": "Forward is built around complete movement systems rather than seasonal noise: fewer products, clearer jobs, longer useful lives.",
+        "imageSide": "right",
+        "image": {
+          "url": "/images/editorial/hero-open-sky.webp",
+          "altText": "Climber on an open granite face under a wide pale sky",
+          "width": 2000,
+          "height": 1445
+        }
+      }
+    },
+    { "type": "standard-statement" },
+    { "type": "stat-band" },
+    {
+      "type": "product-strip",
+      "data": {
+        "products": [
+          { "handle": "weatherline-shell" },
+          { "handle": "traverse-grid-fleece" },
+          { "handle": "drift-insulated-vest" }
+        ]
+      }
+    }
+  ]
+}

--- a/scripts/weaverse-seed/page-field-testing.json
+++ b/scripts/weaverse-seed/page-field-testing.json
@@ -1,0 +1,24 @@
+{
+  "pageType": "CUSTOM",
+  "handle": "field-testing",
+  "name": "Field testing",
+  "sections": [
+    {
+      "type": "editorial-overlay-hero",
+      "data": {
+        "image": {
+          "url": "/images/editorial/trail-movement.webp",
+          "altText": "Runner moving along a high dirt trail at golden hour",
+          "width": 2000,
+          "height": 1333
+        }
+      }
+    },
+    { "type": "numbered-sequence" },
+    {
+      "type": "product-case-study",
+      "data": { "product": { "handle": "talus-trail-shoe" } }
+    },
+    { "type": "editorial-callout" }
+  ]
+}

--- a/scripts/weaverse-seed/page-materials.json
+++ b/scripts/weaverse-seed/page-materials.json
@@ -1,0 +1,34 @@
+{
+  "pageType": "CUSTOM",
+  "handle": "materials",
+  "name": "Materials",
+  "sections": [
+    {
+      "type": "editorial-hero",
+      "data": {
+        "eyebrowLabel": "Custom page / Materials",
+        "heading": "Fewer materials. Better understood.",
+        "lede": "Every fabric, foam, buckle, and compound is selected around useful life, field repair, and performance you can actually feel.",
+        "imageSide": "left",
+        "image": {
+          "url": "/images/editorial/mountain-ridges.webp",
+          "altText": "Layered mountain ridges fading into evening haze",
+          "width": 1800,
+          "height": 1200
+        }
+      }
+    },
+    { "type": "principle-grid" },
+    {
+      "type": "product-tiles",
+      "data": {
+        "products": [
+          { "handle": "weatherline-shell" },
+          { "handle": "traverse-grid-fleece" },
+          { "handle": "talus-trail-shoe" }
+        ]
+      }
+    },
+    { "type": "editorial-callout" }
+  ]
+}

--- a/scripts/weaverse-seed/template-article.json
+++ b/scripts/weaverse-seed/template-article.json
@@ -1,0 +1,6 @@
+{
+  "pageType": "ARTICLE",
+  "handle": "",
+  "description": "Journal article template.",
+  "sections": [{ "type": "article-header" }, { "type": "article-body" }]
+}

--- a/scripts/weaverse-seed/template-collection.json
+++ b/scripts/weaverse-seed/template-collection.json
@@ -1,0 +1,21 @@
+{
+  "pageType": "COLLECTION",
+  "handle": "",
+  "description": "Collection template.",
+  "sections": [
+    { "type": "collection-hero" },
+    {
+      "type": "system-manifest",
+      "data": {
+        "image": {
+          "url": "/images/editorial/mountain-ridges.webp",
+          "altText": "Layered mountain ridges fading into evening haze",
+          "width": 1800,
+          "height": 1200
+        }
+      }
+    },
+    { "type": "collection-grid" },
+    { "type": "field-practice" }
+  ]
+}

--- a/scripts/weaverse-seed/template-index.json
+++ b/scripts/weaverse-seed/template-index.json
@@ -1,0 +1,67 @@
+{
+  "pageType": "INDEX",
+  "handle": "",
+  "description": "Home.",
+  "sections": [
+    {
+      "type": "home-hero",
+      "data": {
+        "featuredProduct": { "handle": "weatherline-shell" },
+        "image": {
+          "url": "/images/editorial/hero-open-sky.webp",
+          "altText": "Climber on an open granite face under a wide pale sky",
+          "width": 2000,
+          "height": 1445
+        }
+      }
+    },
+    {
+      "type": "featured-products",
+      "data": {
+        "products": [
+          { "handle": "weatherline-shell" },
+          { "handle": "traverse-grid-fleece" },
+          { "handle": "ridge-30-field-pack" },
+          { "handle": "talus-trail-shoe" }
+        ]
+      }
+    },
+    {
+      "type": "collection-index",
+      "data": {
+        "collections": [
+          { "handle": "outerwear" },
+          { "handle": "packs" },
+          { "handle": "footwear" }
+        ]
+      }
+    },
+    {
+      "type": "product-spotlight",
+      "data": { "product": { "handle": "drift-insulated-vest" } }
+    },
+    {
+      "type": "material-standard",
+      "data": {
+        "image": {
+          "url": "/images/editorial/mountain-ridges.webp",
+          "altText": "Layered mountain ridges fading into evening haze",
+          "width": 1800,
+          "height": 1200
+        }
+      }
+    },
+    {
+      "type": "kit-callout",
+      "data": {
+        "product": { "handle": "approach-18-day-pack" },
+        "tileProducts": [
+          { "handle": "weatherline-shell" },
+          { "handle": "traverse-grid-fleece" },
+          { "handle": "ridge-30-field-pack" }
+        ]
+      }
+    },
+    { "type": "repair-and-journal" }
+  ]
+}

--- a/scripts/weaverse-seed/template-page.json
+++ b/scripts/weaverse-seed/template-page.json
@@ -1,0 +1,31 @@
+{
+  "pageType": "PAGE",
+  "handle": "",
+  "description": "Shopify page template.",
+  "sections": [
+    {
+      "type": "page-hero",
+      "data": {
+        "image": {
+          "url": "/images/editorial/mountain-ridges.webp",
+          "altText": "Layered mountain ridges fading into evening haze",
+          "width": 1800,
+          "height": 1200
+        }
+      }
+    },
+    { "type": "page-premise" },
+    { "type": "page-values" },
+    {
+      "type": "page-origin",
+      "data": {
+        "image": {
+          "url": "/images/editorial/hero-open-sky.webp",
+          "altText": "Climber on an open granite face under a wide pale sky",
+          "width": 2000,
+          "height": 1445
+        }
+      }
+    }
+  ]
+}

--- a/scripts/weaverse-seed/template-product.json
+++ b/scripts/weaverse-seed/template-product.json
@@ -2,5 +2,12 @@
   "pageType": "PRODUCT",
   "handle": "",
   "description": "Product template. The buy block is theme-owned and renders above these sections.",
-  "sections": [{ "type": "related-products" }]
+  "sections": [
+    {
+      "type": "main-product"
+    },
+    {
+      "type": "related-products"
+    }
+  ]
 }

--- a/scripts/weaverse-seed/template-product.json
+++ b/scripts/weaverse-seed/template-product.json
@@ -1,0 +1,6 @@
+{
+  "pageType": "PRODUCT",
+  "handle": "",
+  "description": "Product template. The buy block is theme-owned and renders above these sections.",
+  "sections": [{ "type": "related-products" }]
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,6 +12,7 @@ import {
   weaverseProjectId,
 } from "@/lib/weaverse/server";
 import { StudioConnect } from "@/lib/weaverse/studio-connect";
+import type { ThemeSettings } from "@/lib/weaverse/theme-schema";
 
 import "./globals.css";
 
@@ -60,9 +61,11 @@ export const viewport: Viewport = {
  */
 async function pageWidthStyle(): Promise<string | null> {
   const theme = await loadWeaverseThemeSettings();
-  const pageWidth = (
-    theme?.themeSettings as { pageWidth?: unknown } | undefined
-  )?.pageWidth;
+  /* Read through the type derived from the schema groups, so renaming the
+   * input or changing its type breaks here rather than silently ignoring the
+   * merchant's setting. */
+  const settings = theme?.themeSettings as Partial<ThemeSettings> | undefined;
+  const pageWidth = settings?.pageWidth;
   if (typeof pageWidth !== "number" || pageWidth <= 0) {
     return null;
   }

--- a/src/app/products/[productHandle]/page.tsx
+++ b/src/app/products/[productHandle]/page.tsx
@@ -1,7 +1,5 @@
 import type { Metadata } from "next";
-import Link from "next/link";
 import { notFound } from "next/navigation";
-import { Suspense } from "react";
 
 import { storefront } from "@/lib/storefront/data-source";
 import type { Product } from "@/lib/storefront/types";
@@ -11,7 +9,6 @@ import {
   type SearchParams,
   weaverseProjectId,
 } from "@/lib/weaverse/server";
-import { ProductDetail, ProductDetailFallback } from "./product-detail";
 
 interface ProductPageProps {
   params: Promise<{ productHandle: string }>;
@@ -51,80 +48,6 @@ async function relatedProducts(product: Product) {
   return related.filter((entry): entry is Product => entry !== null);
 }
 
-function ProductFieldRecord({ product }: { product: Product }) {
-  return (
-    <div className="mt-7.5 border-border-dark border-t">
-      <details className="group border-border-dark border-b" open>
-        <summary className="flex min-h-13.5 list-none items-center justify-between font-body text-micro font-medium tracking-control uppercase after:text-copy-lg after:content-['+'] group-open:after:content-['−'] [&::-webkit-details-marker]:hidden">
-          Why it works
-        </summary>
-        {product.detailParagraphs.map((paragraph) => (
-          <p
-            className="text-label text-text-dark-muted"
-            key={paragraph.slice(0, 32)}
-          >
-            {paragraph}
-          </p>
-        ))}
-      </details>
-      <details className="group border-border-dark border-b">
-        <summary className="flex min-h-13.5 list-none items-center justify-between font-body text-micro font-medium tracking-control uppercase after:text-copy-lg after:content-['+'] group-open:after:content-['−'] [&::-webkit-details-marker]:hidden">
-          Specifications
-        </summary>
-        <dl>
-          {product.specs.map((row) => (
-            <div
-              key={row.label}
-              className="flex justify-between gap-5 border-border-dark border-b py-2.25 text-caption last:border-b-0"
-            >
-              <dt className="font-body text-micro text-text-dark-muted tracking-label uppercase">
-                {row.label}
-              </dt>
-              <dd className="m-0 text-right text-text-inverse">{row.value}</dd>
-            </div>
-          ))}
-        </dl>
-      </details>
-      <details className="group border-border-dark border-b">
-        <summary className="flex min-h-13.5 list-none items-center justify-between font-body text-micro font-medium tracking-control uppercase after:text-copy-lg after:content-['+'] group-open:after:content-['−'] [&::-webkit-details-marker]:hidden">
-          Materials + care
-        </summary>
-        <ul className="mt-0 mb-prose-block pl-[1.2em]">
-          {product.care.map((entry) => (
-            <li className="text-label text-text-muted" key={entry.slice(0, 32)}>
-              {entry}
-            </li>
-          ))}
-        </ul>
-      </details>
-      <details className="group border-border-dark border-b">
-        <summary className="flex min-h-13.5 list-none items-center justify-between font-body text-micro font-medium tracking-control uppercase after:text-copy-lg after:content-['+'] group-open:after:content-['−'] [&::-webkit-details-marker]:hidden">
-          Repair
-        </summary>
-        <p className="text-label text-text-dark-muted">{product.repair}</p>
-        <p>
-          <Link
-            className="inline-flex min-h-touch items-center gap-3.5 border-text-inverse border-b font-body text-ui font-medium tracking-link uppercase after:text-control-lg after:font-normal after:content-['→'] after:transition-transform after:duration-200 after:ease-standard hover:after:translate-x-1.25"
-            href="/pages/field-repair"
-          >
-            The repairs programme
-          </Link>
-        </p>
-      </details>
-    </div>
-  );
-}
-
-/**
- * Product.
- *
- * The buy block is not composable — gallery, colorway and size selection,
- * price, availability, and the cart handoff own variant identity and URL query
- * state, so they stay theme-owned and render above whatever Weaverse composes.
- * `PRODUCT` therefore composes the surfaces *around* the buy block, and the
- * product itself reaches them through `dataContext` because the route, not a
- * merchant, decides which product this template is rendering.
- */
 export default async function ProductPage(props: ProductPageProps) {
   const { productHandle } = await props.params;
   const [product, page, projectId] = await Promise.all([
@@ -141,23 +64,12 @@ export default async function ProductPage(props: ProductPageProps) {
     notFound();
   }
   const related = await relatedProducts(product);
-  const fieldRecord = <ProductFieldRecord product={product} />;
 
   return (
-    <>
-      <Suspense
-        fallback={
-          <ProductDetailFallback product={product} fieldRecord={fieldRecord} />
-        }
-      >
-        <ProductDetail product={product} fieldRecord={fieldRecord} />
-      </Suspense>
-
-      <WeaversePage
-        data={page}
-        dataContext={{ product, products: related }}
-        projectId={projectId}
-      />
-    </>
+    <WeaversePage
+      data={page}
+      dataContext={{ product, products: related }}
+      projectId={projectId}
+    />
   );
 }

--- a/src/app/products/[productHandle]/page.tsx
+++ b/src/app/products/[productHandle]/page.tsx
@@ -3,12 +3,15 @@ import { notFound } from "next/navigation";
 
 import { storefront } from "@/lib/storefront/data-source";
 import type { Product } from "@/lib/storefront/types";
+import { StorefrontDataProvider } from "@/lib/weaverse/data-context";
 import { WeaversePage } from "@/lib/weaverse/page";
+import { pageRenders } from "@/lib/weaverse/page-payload";
 import {
   loadWeaversePage,
   type SearchParams,
   weaverseProjectId,
 } from "@/lib/weaverse/server";
+import MainProduct from "@/sections/main-product";
 
 interface ProductPageProps {
   params: Promise<{ productHandle: string }>;
@@ -66,10 +69,22 @@ export default async function ProductPage(props: ProductPageProps) {
   const related = await relatedProducts(product);
 
   return (
-    <WeaversePage
-      data={page}
-      dataContext={{ product, products: related }}
-      projectId={projectId}
-    />
+    <>
+      {/* The buy block is the one surface a product URL cannot be without. It
+       * is a section so Studio can place things around it, but a template that
+       * has not been seeded — or one a merchant removed it from — must not
+       * leave a product page with no gallery, no variant selection and no way
+       * to add to cart. So the route renders it when the page does not. */}
+      {pageRenders(page, "main-product") ? null : (
+        <StorefrontDataProvider value={{ product }}>
+          <MainProduct />
+        </StorefrontDataProvider>
+      )}
+      <WeaversePage
+        data={page}
+        dataContext={{ product, products: related }}
+        projectId={projectId}
+      />
+    </>
   );
 }

--- a/src/components/button/index.tsx
+++ b/src/components/button/index.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 
 import { cn } from "@/lib/cn";
-import { cta } from "@/lib/presentation/variants";
+import { cta, textLink } from "@/lib/presentation/variants";
 import {
   elementAttributes,
   type WeaverseElementProps,
@@ -14,7 +14,7 @@ type ButtonIntent = "primary" | "signal" | "light" | "outline";
 export interface ButtonProps extends WeaverseElementProps {
   label: string;
   href: string;
-  intent?: ButtonIntent;
+  intent?: "link" | ButtonIntent;
   className?: string;
 }
 
@@ -34,10 +34,17 @@ function Button({
   label,
   ...rest
 }: ButtonProps) {
+  /* `link` is the underlined arrow link the sections already use for a
+   * secondary destination. It lives here rather than as a fifth element so a
+   * merchant can switch a call to action between weights without swapping the
+   * item out and losing its settings. */
   return (
     <Link
       {...elementAttributes(rest)}
-      className={cn(cta({ intent }), className)}
+      className={cn(
+        intent === "link" ? textLink() : cta({ intent }),
+        className,
+      )}
       href={href}
     >
       {label}

--- a/src/components/button/schema.ts
+++ b/src/components/button/schema.ts
@@ -17,6 +17,7 @@ export const schema = createSchema({
           configs: {
             options: [
               { value: "primary", label: "Primary" },
+              { value: "link", label: "Text link" },
               { value: "signal", label: "Signal" },
               { value: "light", label: "Light" },
               { value: "outline", label: "Outline" },

--- a/src/components/section-content/index.tsx
+++ b/src/components/section-content/index.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { cva, type VariantProps } from "class-variance-authority";
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/cn";
+import {
+  elementAttributes,
+  type WeaverseElementProps,
+} from "@/sections/weaverse-element";
+
+const variants = cva("flex min-w-0 flex-col", {
+  variants: {
+    alignment: {
+      start: "items-start text-left",
+      center: "items-center text-center",
+      end: "items-end text-right",
+    },
+    justify: {
+      start: "justify-start",
+      center: "justify-center",
+      end: "justify-end",
+    },
+  },
+  defaultVariants: { alignment: "start", justify: "start" },
+});
+
+interface SectionContentProps
+  extends VariantProps<typeof variants>,
+    WeaverseElementProps {
+  children?: ReactNode;
+}
+
+/**
+ * A column of shared elements inside a section.
+ *
+ * This is the piece that was missing: `heading`, `subheading`, `paragraph` and
+ * `button` were registered but had nowhere to be placed, because no section
+ * accepted children. A section now nests one of these per layout slot — a
+ * two-column band uses two — and the merchant fills each with elements rather
+ * than editing one flat string per slot.
+ */
+function SectionContent({
+  alignment,
+  justify,
+  children,
+  ...rest
+}: SectionContentProps) {
+  return (
+    <div
+      {...elementAttributes(rest)}
+      className={cn(variants({ alignment, justify }))}
+    >
+      {children}
+    </div>
+  );
+}
+
+export default SectionContent;
+
+export { schema } from "./schema";

--- a/src/components/section-content/schema.ts
+++ b/src/components/section-content/schema.ts
@@ -1,0 +1,47 @@
+import { createSchema } from "@weaverse/schema";
+
+export const schema = createSchema({
+  type: "section-content",
+  title: "Content",
+  childTypes: ["subheading", "heading", "paragraph", "button"],
+  settings: [
+    {
+      group: "Layout",
+      inputs: [
+        {
+          type: "select",
+          name: "alignment",
+          label: "Alignment",
+          configs: {
+            options: [
+              { value: "start", label: "Left" },
+              { value: "center", label: "Center" },
+              { value: "end", label: "Right" },
+            ],
+          },
+          helpText: "Overrides the alignment of every element inside.",
+        },
+        {
+          type: "select",
+          name: "justify",
+          label: "Vertical position",
+          configs: {
+            options: [
+              { value: "start", label: "Top" },
+              { value: "center", label: "Middle" },
+              { value: "end", label: "Bottom" },
+            ],
+          },
+        },
+      ],
+    },
+  ],
+  presets: {
+    alignment: "start",
+    children: [
+      { type: "subheading", content: "Subheading" },
+      { type: "heading", content: "Section heading" },
+      { type: "paragraph", content: "Supporting copy for this section." },
+    ],
+  },
+});

--- a/src/components/section/index.tsx
+++ b/src/components/section/index.tsx
@@ -1,34 +1,19 @@
 "use client";
 
 import { cva, type VariantProps } from "class-variance-authority";
-import Image from "next/image";
-import type { ElementType, ReactNode } from "react";
+import type { ReactNode } from "react";
 
 import { cn } from "@/lib/cn";
-import type { StorefrontImage } from "@/lib/storefront/types";
-import { weaverseImage } from "@/lib/weaverse/image";
 import {
   elementAttributes,
   type WeaverseElementProps,
 } from "@/sections/weaverse-element";
 
 /**
- * Two recipes, not one with two call sites: cva fills in `defaultVariants` for
- * every variant a call omits, so a single recipe would put the width classes
- * on the outer element as well and drop the gutter.
+ * The measure stays with the gutter, the way `SHELL_SECTION_CLASS` composed
+ * it, so moving a section onto this shell does not shift its content edge.
  */
-const outerVariants = cva("relative", {
-  variants: {
-    width: { full: "", stretch: "", fixed: "" },
-  },
-  defaultVariants: { width: "fixed" },
-});
-
-/**
- * The measure itself stays with the gutter, the way `SHELL_SECTION_CLASS`
- * composed it, so converting a section does not move its content edge.
- */
-const innerVariants = cva("relative", {
+const variants = cva("relative", {
   variants: {
     width: {
       full: "w-full",
@@ -48,19 +33,10 @@ const innerVariants = cva("relative", {
 });
 
 export interface SectionProps
-  extends VariantProps<typeof innerVariants>,
+  extends VariantProps<typeof variants>,
     WeaverseElementProps {
-  as?: ElementType;
   /** Space between direct children, in px. */
   gap?: number;
-  backgroundFor?: "section" | "content";
-  backgroundColor?: string;
-  /** A Builder image value, a StorefrontImage, or nothing. */
-  backgroundImage?: StorefrontImage | unknown;
-  backgroundFit?: "cover" | "contain";
-  enableOverlay?: boolean;
-  overlayColor?: string;
-  overlayOpacity?: number;
   containerClassName?: string;
   "aria-labelledby"?: string;
   children?: ReactNode;
@@ -69,73 +45,26 @@ export interface SectionProps
 /**
  * The shell every composed section renders inside.
  *
- * Width, padding, background, and overlay are the settings almost every
- * section wants, so they are declared once here and spread into a schema from
- * `./inputs`. Sections that hardcoded `SHELL_SECTION_CLASS` got the same
- * measure with none of it editable; going through this component is what lets
- * a merchant change the page measure globally and override it per section.
+ * Width and vertical padding are the settings almost every section wants, so
+ * they are declared once here and spread into a schema from `./inputs`.
+ * Sections that hardcoded `SHELL_SECTION_CLASS` got the same measure with none
+ * of it editable; going through this component is what lets a merchant change
+ * the page measure globally and override it per section.
  */
 export function Section({
-  as: Component = "section",
-  backgroundColor,
-  backgroundFit = "cover",
-  backgroundFor = "section",
-  backgroundImage,
   children,
   className,
   containerClassName,
-  enableOverlay,
   gap,
-  overlayColor = "#000000",
-  overlayOpacity = 50,
   verticalPadding,
   width,
   ...rest
 }: SectionProps) {
-  const image = weaverseImage(backgroundImage);
-  const onContent = backgroundFor === "content";
-  const dressing = (
-    <>
-      {image === null ? null : (
-        <Image
-          alt={image.alt}
-          className={cn(
-            "absolute inset-0 h-full w-full",
-            backgroundFit === "contain" ? "object-contain" : "object-cover",
-          )}
-          height={image.height}
-          sizes="100vw"
-          src={image.src}
-          width={image.width}
-        />
-      )}
-      {enableOverlay === true && (
-        <div
-          aria-hidden="true"
-          className="absolute inset-0"
-          style={{
-            backgroundColor: overlayColor,
-            opacity: overlayOpacity / 100,
-          }}
-        />
-      )}
-    </>
-  );
-
   return (
-    <Component
-      {...elementAttributes(rest)}
-      className={cn(outerVariants({ width }), className)}
-      style={onContent ? undefined : { backgroundColor }}
-    >
-      {onContent ? null : dressing}
+    <section {...elementAttributes(rest)} className={cn("relative", className)}>
       <div
-        className={cn(
-          innerVariants({ verticalPadding, width }),
-          containerClassName,
-        )}
+        className={cn(variants({ verticalPadding, width }), containerClassName)}
         style={{
-          ...(onContent ? { backgroundColor } : undefined),
           /* Spacing only. Setting `display` here would win over whatever
            * `containerClassName` asks for, which collapsed the multi-column
            * bands into one column the moment a merchant touched the spacing
@@ -147,9 +76,8 @@ export function Section({
             : { display: "flex", flexDirection: "column" }),
         }}
       >
-        {onContent ? dressing : null}
         {children}
       </div>
-    </Component>
+    </section>
   );
 }

--- a/src/components/section/index.tsx
+++ b/src/components/section/index.tsx
@@ -136,8 +136,13 @@ export function Section({
         )}
         style={{
           ...(onContent ? { backgroundColor } : undefined),
+          /* Spacing only. Setting `display` here would win over whatever
+           * `containerClassName` asks for, which collapsed the multi-column
+           * bands into one column the moment a merchant touched the spacing
+           * control. A section that lays its own container out keeps that
+           * layout; only one with no layout of its own is stacked. */
           ...(gap === undefined ? undefined : { gap: `${gap}px` }),
-          ...(gap === undefined
+          ...(gap === undefined || containerClassName !== undefined
             ? undefined
             : { display: "flex", flexDirection: "column" }),
         }}

--- a/src/components/section/inputs.ts
+++ b/src/components/section/inputs.ts
@@ -2,9 +2,9 @@
  * The settings every section shares.
  *
  * A section schema spreads these rather than restating them, so "content
- * width", "vertical padding", and the background controls mean the same thing
- * everywhere and a merchant learns them once. Exported as plain data so a
- * schema module stays importable outside Next.
+ * width" and "vertical padding" mean the same thing everywhere and a merchant
+ * learns them once. Exported as plain data so a schema module stays importable
+ * outside Next.
  */
 
 import type { InspectorGroup } from "@weaverse/schema";
@@ -43,54 +43,4 @@ export const layoutInputs: SectionInputs = [
       ],
     },
   },
-];
-
-/** Background: a flat colour, optionally behind an image. */
-export const backgroundInputs: SectionInputs = [
-  {
-    type: "select",
-    name: "backgroundFor",
-    label: "Background for",
-    configs: {
-      options: [
-        { value: "section", label: "Full section" },
-        { value: "content", label: "Content only" },
-      ],
-    },
-  },
-  { type: "color", name: "backgroundColor", label: "Background colour" },
-  { type: "image", name: "backgroundImage", label: "Background image" },
-  {
-    type: "select",
-    name: "backgroundFit",
-    label: "Image fit",
-    configs: {
-      options: [
-        { value: "cover", label: "Cover" },
-        { value: "contain", label: "Contain" },
-      ],
-    },
-  },
-];
-
-/**
- * Overlay: only meaningful over a background image, which is why it is a
- * separate group a section can leave out.
- */
-export const overlayInputs: SectionInputs = [
-  { type: "switch", name: "enableOverlay", label: "Enable overlay" },
-  { type: "color", name: "overlayColor", label: "Overlay colour" },
-  {
-    type: "range",
-    name: "overlayOpacity",
-    label: "Overlay opacity",
-    configs: { min: 0, max: 100, step: 5, unit: "%" },
-  },
-];
-
-/** The three groups a section normally declares before its own content. */
-export const sectionSettings: InspectorGroup[] = [
-  { group: "Layout", inputs: layoutInputs },
-  { group: "Background", inputs: backgroundInputs },
-  { group: "Overlay", inputs: overlayInputs },
 ];

--- a/src/components/subheading/schema.ts
+++ b/src/components/subheading/schema.ts
@@ -26,6 +26,6 @@ export const schema = createSchema({
   ],
   presets: {
     content: "Subheading",
-    tone: "muted",
+    tone: "strong",
   },
 });

--- a/src/lib/weaverse/components.ts
+++ b/src/lib/weaverse/components.ts
@@ -39,6 +39,7 @@ import * as FeaturedProducts from "@/sections/featured-products";
 import * as FieldPractice from "@/sections/field-practice";
 import * as HomeHero from "@/sections/home-hero";
 import * as KitCallout from "@/sections/kit-callout";
+import * as MainProduct from "@/sections/main-product";
 import * as MaterialStandard from "@/sections/material-standard";
 import * as NumberedSequence from "@/sections/numbered-sequence";
 import * as PageHero from "@/sections/page-hero";
@@ -92,6 +93,7 @@ export const WEAVERSE_COMPONENTS: WeaverseNextComponent[] = [
   entry(RepairAndJournal),
 
   /* PRODUCT */
+  entry(MainProduct),
   entry(RelatedProducts),
 
   /* COLLECTION */

--- a/src/lib/weaverse/components.ts
+++ b/src/lib/weaverse/components.ts
@@ -25,6 +25,7 @@ import type { WeaverseNextComponent } from "@weaverse/next";
 import * as Button from "@/components/button";
 import * as Heading from "@/components/heading";
 import * as Paragraph from "@/components/paragraph";
+import * as SectionContent from "@/components/section-content";
 import * as Subheading from "@/components/subheading";
 import * as ArticleBody from "@/sections/article-body";
 import * as ArticleHeader from "@/sections/article-header";
@@ -79,6 +80,7 @@ export const WEAVERSE_COMPONENTS: WeaverseNextComponent[] = [
   entry(Subheading),
   entry(Paragraph),
   entry(Button),
+  entry(SectionContent),
 
   /* INDEX */
   entry(HomeHero),

--- a/src/lib/weaverse/page-payload.ts
+++ b/src/lib/weaverse/page-payload.ts
@@ -28,3 +28,15 @@ export function hasAuthoredSections(
     return Array.isArray(children) && children.length > 0;
   });
 }
+
+/** Whether a composed page already places a given component type. */
+export function pageRenders(
+  page: WeaverseNextLoaderData | null | undefined,
+  type: string,
+): boolean {
+  const items = page?.page?.items;
+  if (!Array.isArray(items)) {
+    return false;
+  }
+  return items.some((item) => (item as { type?: unknown }).type === type);
+}

--- a/src/lib/weaverse/section-schemas.ts
+++ b/src/lib/weaverse/section-schemas.ts
@@ -15,6 +15,7 @@ import type { SchemaType } from "@weaverse/schema";
 import { schema as button } from "@/components/button/schema";
 import { schema as heading } from "@/components/heading/schema";
 import { schema as paragraph } from "@/components/paragraph/schema";
+import { schema as sectionContent } from "@/components/section-content/schema";
 import { schema as subheading } from "@/components/subheading/schema";
 import { schema as articleBody } from "@/sections/article-body/schema";
 import { schema as articleHeader } from "@/sections/article-header/schema";
@@ -51,6 +52,7 @@ export const SECTION_SCHEMAS: readonly SchemaType[] = [
   subheading,
   paragraph,
   button,
+  sectionContent,
 
   /* INDEX */
   homeHero,

--- a/src/lib/weaverse/section-schemas.ts
+++ b/src/lib/weaverse/section-schemas.ts
@@ -29,6 +29,7 @@ import { schema as featuredProducts } from "@/sections/featured-products/schema"
 import { schema as fieldPractice } from "@/sections/field-practice/schema";
 import { schema as homeHero } from "@/sections/home-hero/schema";
 import { schema as kitCallout } from "@/sections/kit-callout/schema";
+import { schema as mainProduct } from "@/sections/main-product/schema";
 import { schema as materialStandard } from "@/sections/material-standard/schema";
 import { schema as numberedSequence } from "@/sections/numbered-sequence/schema";
 import { schema as pageHero } from "@/sections/page-hero/schema";
@@ -64,6 +65,7 @@ export const SECTION_SCHEMAS: readonly SchemaType[] = [
   repairAndJournal,
 
   /* PRODUCT */
+  mainProduct,
   relatedProducts,
 
   /* COLLECTION */

--- a/src/sections/editorial-callout/index.tsx
+++ b/src/sections/editorial-callout/index.tsx
@@ -1,46 +1,30 @@
 "use client";
 
-import Link from "next/link";
-import { cta, eyebrow, sectionHeading } from "@/lib/presentation/variants";
-import {
-  elementAttributes,
-  type WeaverseElementProps,
-} from "../weaverse-element";
+import type { ReactNode } from "react";
+
+import { Section } from "@/components/section";
+import type { WeaverseElementProps } from "../weaverse-element";
 
 interface EditorialCalloutProps extends WeaverseElementProps {
-  eyebrowLabel: string;
-  heading: string;
-  body: string;
-  ctaLabel: string;
-  ctaHref: string;
+  children?: ReactNode;
 }
 
 /**
  * Three-column closing callout: heading block, body copy, single call to
  * action. Used by the Materials and Field Testing custom pages.
+ *
+ * The section owns the three-column split; each column is a `section-content`
+ * child, so what goes in them — and whether the call to action is a button or
+ * a text link — is the merchant's decision rather than a fixed prop shape.
  */
-function EditorialCallout({
-  eyebrowLabel,
-  heading,
-  body,
-  ctaLabel,
-  ctaHref,
-  ...rest
-}: EditorialCalloutProps) {
+function EditorialCallout({ children, ...rest }: EditorialCalloutProps) {
   return (
-    <section
-      {...elementAttributes(rest)}
-      className="mx-auto grid w-full max-w-page grid-cols-spec-row items-end gap-11.25 px-page-gutter py-section-block max-md:grid-cols-1"
+    <Section
+      {...rest}
+      containerClassName="grid grid-cols-spec-row items-end gap-11.25 max-md:grid-cols-1"
     >
-      <div>
-        <p className={eyebrow()}>{eyebrowLabel}</p>
-        <h2 className={sectionHeading()}>{heading}</h2>
-      </div>
-      <p>{body}</p>
-      <Link className={cta()} href={ctaHref}>
-        {ctaLabel}
-      </Link>
-    </section>
+      {children}
+    </Section>
   );
 }
 

--- a/src/sections/editorial-callout/schema.ts
+++ b/src/sections/editorial-callout/schema.ts
@@ -1,48 +1,44 @@
 import { createSchema } from "@weaverse/schema";
 
+import { layoutInputs } from "@/components/section/inputs";
+
 export const schema = createSchema({
   type: "editorial-callout",
   title: "Editorial callout",
-  settings: [
-    {
-      group: "Content",
-      inputs: [
-        {
-          type: "text",
-          name: "eyebrowLabel",
-          label: "Eyebrow",
-        },
-        {
-          type: "text",
-          name: "heading",
-          label: "Heading",
-        },
-        {
-          type: "textarea",
-          name: "body",
-          label: "Body",
-        },
-        {
-          type: "text",
-          name: "ctaLabel",
-          label: "CTA label",
-        },
-        {
-          type: "url",
-          name: "ctaHref",
-          label: "CTA link",
-        },
-      ],
-    },
-  ],
-  enabledOn: {
-    pages: ["PAGE", "CUSTOM"],
-  },
+  childTypes: ["section-content"],
+  enabledOn: { pages: ["PAGE", "CUSTOM"] },
+  settings: [{ group: "Layout", inputs: layoutInputs }],
   presets: {
-    eyebrowLabel: "What this means",
-    heading: "Buy once. Repair often.",
-    body: "A shorter catalog means each object gets the attention it needs to last, and a repair desk that keeps it moving.",
-    ctaLabel: "Explore the catalog",
-    ctaHref: "/shop",
+    children: [
+      {
+        type: "section-content",
+        children: [
+          { type: "subheading", content: "What this means" },
+          { type: "heading", content: "Buy once. Repair often." },
+        ],
+      },
+      {
+        type: "section-content",
+        children: [
+          {
+            type: "paragraph",
+            content:
+              "A shorter catalog means each object gets the attention it needs to last, and a repair desk that keeps it moving.",
+          },
+        ],
+      },
+      {
+        type: "section-content",
+        justify: "end",
+        children: [
+          {
+            type: "button",
+            label: "Explore the catalog",
+            href: "/shop",
+            intent: "primary",
+          },
+        ],
+      },
+    ],
   },
 });

--- a/src/sections/field-practice/index.tsx
+++ b/src/sections/field-practice/index.tsx
@@ -1,43 +1,29 @@
 "use client";
 
-import Link from "next/link";
+import type { ReactNode } from "react";
+
 import { Section } from "@/components/section";
-import { eyebrow, sectionHeading, textLink } from "@/lib/presentation/variants";
 import type { WeaverseElementProps } from "../weaverse-element";
 
 interface FieldPracticeProps extends WeaverseElementProps {
-  eyebrowLabel: string;
-  heading: string;
-  body: string;
-  linkLabel: string;
-  linkHref: string;
+  children?: ReactNode;
 }
 
-/** A closing two-column note: heading on the left, copy and link on the right. */
-function FieldPractice({
-  eyebrowLabel,
-  heading,
-  body,
-  linkLabel,
-  linkHref,
-  ...rest
-}: FieldPracticeProps) {
+/**
+ * A closing two-column note.
+ *
+ * The section owns the split, not the words: each column is a `section-content`
+ * child a merchant fills with elements, so the heading size, the copy width and
+ * whether the link is a button or a text link are all editable — none of which
+ * was true when the four strings were flat settings on this component.
+ */
+function FieldPractice({ children, ...rest }: FieldPracticeProps) {
   return (
-    <Section {...rest}>
-      <div className="grid grid-cols-split-85 items-start gap-page-gap max-md:grid-cols-1">
-        <div>
-          <p className={eyebrow()}>{eyebrowLabel}</p>
-          <h2 className={sectionHeading()}>{heading}</h2>
-        </div>
-        <div>
-          <p className="max-w-lede text-lede leading-lede text-text-muted">
-            {body}
-          </p>
-          <Link className={textLink()} href={linkHref}>
-            {linkLabel}
-          </Link>
-        </div>
-      </div>
+    <Section
+      {...rest}
+      containerClassName="grid grid-cols-split-85 items-start gap-page-gap max-md:grid-cols-1"
+    >
+      {children}
     </Section>
   );
 }

--- a/src/sections/field-practice/schema.ts
+++ b/src/sections/field-practice/schema.ts
@@ -5,47 +5,34 @@ import { layoutInputs } from "@/components/section/inputs";
 export const schema = createSchema({
   type: "field-practice",
   title: "Field practice",
-  settings: [
-    { group: "Layout", inputs: layoutInputs },
-    {
-      group: "Content",
-      inputs: [
-        {
-          type: "text",
-          name: "eyebrowLabel",
-          label: "Eyebrow",
-        },
-        {
-          type: "text",
-          name: "heading",
-          label: "Heading",
-        },
-        {
-          type: "textarea",
-          name: "body",
-          label: "Body",
-        },
-        {
-          type: "text",
-          name: "linkLabel",
-          label: "Link label",
-        },
-        {
-          type: "url",
-          name: "linkHref",
-          label: "Link target",
-        },
-      ],
-    },
-  ],
-  enabledOn: {
-    pages: ["COLLECTION"],
-  },
+  childTypes: ["section-content"],
+  enabledOn: { pages: ["COLLECTION"] },
+  settings: [{ group: "Layout", inputs: layoutInputs }],
   presets: {
-    eyebrowLabel: "Field practice",
-    heading: "Let the route set the pace.",
-    body: "Efficient movement is not about speed. It is about keeping effort even, noticing what changes, and reaching the last descent with enough attention left to enjoy it.",
-    linkLabel: "More field stories",
-    linkHref: "/journal",
+    children: [
+      {
+        type: "section-content",
+        children: [
+          { type: "subheading", content: "Field practice" },
+          { type: "heading", content: "Let the route set the pace." },
+        ],
+      },
+      {
+        type: "section-content",
+        children: [
+          {
+            type: "paragraph",
+            content:
+              "Efficient movement is not about speed. It is about keeping effort even, noticing what changes, and reaching the last descent with enough attention left to enjoy it.",
+          },
+          {
+            type: "button",
+            label: "More field stories",
+            href: "/journal",
+            intent: "link",
+          },
+        ],
+      },
+    ],
   },
 });

--- a/src/sections/kit-callout/index.tsx
+++ b/src/sections/kit-callout/index.tsx
@@ -54,7 +54,6 @@ function KitCallout({
   return (
     <Section
       {...rest}
-      verticalPadding="none"
       containerClassName={cn(
         "grid grid-cols-[0.55fr_1.45fr] items-end gap-15 max-md:grid-cols-1",
         VIEWPORT_SECTION_CLASS,

--- a/src/sections/main-product/field-record.tsx
+++ b/src/sections/main-product/field-record.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import Link from "next/link";
+
+import type { Product } from "@/lib/storefront/types";
+
+/**
+ * The disclosure stack under the buy block.
+ *
+ * It reads only from the product, so it moved out of the route with the rest
+ * of the block. Splitting its four panels into separate Studio items is a
+ * separate decision and needs its own argument.
+ */
+export function ProductFieldRecord({ product }: { product: Product }) {
+  return (
+    <div className="mt-7.5 border-border-dark border-t">
+      <details className="group border-border-dark border-b" open>
+        <summary className="flex min-h-13.5 list-none items-center justify-between font-body text-micro font-medium tracking-control uppercase after:text-copy-lg after:content-['+'] group-open:after:content-['−'] [&::-webkit-details-marker]:hidden">
+          Why it works
+        </summary>
+        {product.detailParagraphs.map((paragraph) => (
+          <p
+            className="text-label text-text-dark-muted"
+            key={paragraph.slice(0, 32)}
+          >
+            {paragraph}
+          </p>
+        ))}
+      </details>
+      <details className="group border-border-dark border-b">
+        <summary className="flex min-h-13.5 list-none items-center justify-between font-body text-micro font-medium tracking-control uppercase after:text-copy-lg after:content-['+'] group-open:after:content-['−'] [&::-webkit-details-marker]:hidden">
+          Specifications
+        </summary>
+        <dl>
+          {product.specs.map((row) => (
+            <div
+              key={row.label}
+              className="flex justify-between gap-5 border-border-dark border-b py-2.25 text-caption last:border-b-0"
+            >
+              <dt className="font-body text-micro text-text-dark-muted tracking-label uppercase">
+                {row.label}
+              </dt>
+              <dd className="m-0 text-right text-text-inverse">{row.value}</dd>
+            </div>
+          ))}
+        </dl>
+      </details>
+      <details className="group border-border-dark border-b">
+        <summary className="flex min-h-13.5 list-none items-center justify-between font-body text-micro font-medium tracking-control uppercase after:text-copy-lg after:content-['+'] group-open:after:content-['−'] [&::-webkit-details-marker]:hidden">
+          Materials + care
+        </summary>
+        <ul className="mt-0 mb-prose-block pl-[1.2em]">
+          {product.care.map((entry) => (
+            <li className="text-label text-text-muted" key={entry.slice(0, 32)}>
+              {entry}
+            </li>
+          ))}
+        </ul>
+      </details>
+      <details className="group border-border-dark border-b">
+        <summary className="flex min-h-13.5 list-none items-center justify-between font-body text-micro font-medium tracking-control uppercase after:text-copy-lg after:content-['+'] group-open:after:content-['−'] [&::-webkit-details-marker]:hidden">
+          Repair
+        </summary>
+        <p className="text-label text-text-dark-muted">{product.repair}</p>
+        <p>
+          <Link
+            className="inline-flex min-h-touch items-center gap-3.5 border-text-inverse border-b font-body text-ui font-medium tracking-link uppercase after:text-control-lg after:font-normal after:content-['→'] after:transition-transform after:duration-200 after:ease-standard hover:after:translate-x-1.25"
+            href="/pages/field-repair"
+          >
+            The repairs programme
+          </Link>
+        </p>
+      </details>
+    </div>
+  );
+}
+
+/**
+ * Product.
+ *
+ * The buy block is not composable — gallery, colorway and size selection,
+ * price, availability, and the cart handoff own variant identity and URL query
+ * state, so they stay theme-owned and render above whatever Weaverse composes.
+ * `PRODUCT` therefore composes the surfaces *around* the buy block, and the
+ * product itself reaches them through `dataContext` because the route, not a
+ * merchant, decides which product this template is rendering.
+ */

--- a/src/sections/main-product/index.tsx
+++ b/src/sections/main-product/index.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { Suspense } from "react";
+import {
+  ProductDetail,
+  ProductDetailFallback,
+} from "@/app/products/[productHandle]/product-detail";
+import { useStorefrontContext } from "@/lib/weaverse/data-context";
+import {
+  elementAttributes,
+  type WeaverseElementProps,
+} from "../weaverse-element";
+import { ProductFieldRecord } from "./field-record";
+
+/**
+ * The product buy block.
+ *
+ * Theme-owned means the logic lives in code, not that the surface is invisible
+ * to Studio. Gallery, colorway and size selection, price, availability and the
+ * cart handoff stay inside `ProductDetail` — they own variant identity and the
+ * `colorway`/`size` query state — while a merchant decides where the block sits
+ * among the product page's sections and what surrounds it.
+ */
+function MainProduct({ ...rest }: WeaverseElementProps) {
+  const { product } = useStorefrontContext();
+  if (product === undefined) return null;
+  const fieldRecord = <ProductFieldRecord product={product} />;
+  return (
+    <div {...elementAttributes(rest)}>
+      <Suspense
+        fallback={
+          <ProductDetailFallback fieldRecord={fieldRecord} product={product} />
+        }
+      >
+        <ProductDetail fieldRecord={fieldRecord} product={product} />
+      </Suspense>
+    </div>
+  );
+}
+
+export default MainProduct;
+
+export { schema } from "./schema";

--- a/src/sections/main-product/schema.ts
+++ b/src/sections/main-product/schema.ts
@@ -1,0 +1,10 @@
+import { createSchema } from "@weaverse/schema";
+
+export const schema = createSchema({
+  type: "main-product",
+  title: "Main product",
+  limit: 1,
+  enabledOn: { pages: ["PRODUCT"] },
+  settings: [],
+  presets: {},
+});

--- a/src/sections/numbered-sequence/index.tsx
+++ b/src/sections/numbered-sequence/index.tsx
@@ -1,11 +1,9 @@
 "use client";
 
+import { Section } from "@/components/section";
 import { eyebrow, sectionHeading } from "@/lib/presentation/variants";
 import { parseRows } from "../parse";
-import {
-  elementAttributes,
-  type WeaverseElementProps,
-} from "../weaverse-element";
+import type { WeaverseElementProps } from "../weaverse-element";
 
 /** One numbered sequence step: index column, then the step description. */
 const SEQUENCE_STEP_CLASS =
@@ -26,9 +24,9 @@ function NumberedSequence({
   ...rest
 }: NumberedSequenceProps) {
   return (
-    <section
-      {...elementAttributes(rest)}
-      className="mx-auto grid w-full max-w-page grid-cols-split-70 gap-20 px-page-gutter py-section-block max-md:grid-cols-1"
+    <Section
+      {...rest}
+      containerClassName="grid grid-cols-split-70 gap-20 max-md:grid-cols-1"
     >
       <header>
         <p className={eyebrow()}>{eyebrowLabel}</p>
@@ -47,7 +45,7 @@ function NumberedSequence({
           </li>
         ))}
       </ol>
-    </section>
+    </Section>
   );
 }
 

--- a/src/sections/numbered-sequence/schema.ts
+++ b/src/sections/numbered-sequence/schema.ts
@@ -1,9 +1,12 @@
 import { createSchema } from "@weaverse/schema";
 
+import { layoutInputs } from "@/components/section/inputs";
+
 export const schema = createSchema({
   type: "numbered-sequence",
   title: "Numbered sequence",
   settings: [
+    { group: "Layout", inputs: layoutInputs },
     {
       group: "Content",
       inputs: [

--- a/src/sections/page-values/index.tsx
+++ b/src/sections/page-values/index.tsx
@@ -4,12 +4,13 @@ import {
   RichTextParagraph,
   richTextParagraphKey,
 } from "@/components/rich-text-paragraph";
-import { Section } from "@/components/section";
+import { Section, type SectionProps } from "@/components/section";
 import { cn } from "@/lib/cn";
 import { useStorefrontContext } from "@/lib/weaverse/data-context";
 import type { WeaverseElementProps } from "../weaverse-element";
 
 interface PageValuesProps extends WeaverseElementProps {
+  verticalPadding?: SectionProps["verticalPadding"];
   eyebrowSuffix: string;
 }
 
@@ -19,12 +20,16 @@ interface PageValuesProps extends WeaverseElementProps {
  * Renders the page's body sections after the premise, so the card count
  * follows the page a merchant wrote rather than a template setting.
  */
-function PageValues({ eyebrowSuffix, ...rest }: PageValuesProps) {
+function PageValues({
+  eyebrowSuffix,
+  verticalPadding = "compact",
+  ...rest
+}: PageValuesProps) {
   const { page } = useStorefrontContext();
   const sections = page?.sections.slice(1) ?? [];
   if (sections.length === 0) return null;
   return (
-    <Section {...rest} verticalPadding="compact">
+    <Section {...rest} verticalPadding={verticalPadding}>
       <div className="grid grid-cols-12 gap-3 max-sm:grid-cols-1">
         {sections.map((section, index) => (
           <article

--- a/src/sections/page-values/index.tsx
+++ b/src/sections/page-values/index.tsx
@@ -4,12 +4,10 @@ import {
   RichTextParagraph,
   richTextParagraphKey,
 } from "@/components/rich-text-paragraph";
+import { Section } from "@/components/section";
 import { cn } from "@/lib/cn";
 import { useStorefrontContext } from "@/lib/weaverse/data-context";
-import {
-  elementAttributes,
-  type WeaverseElementProps,
-} from "../weaverse-element";
+import type { WeaverseElementProps } from "../weaverse-element";
 
 interface PageValuesProps extends WeaverseElementProps {
   eyebrowSuffix: string;
@@ -26,10 +24,7 @@ function PageValues({ eyebrowSuffix, ...rest }: PageValuesProps) {
   const sections = page?.sections.slice(1) ?? [];
   if (sections.length === 0) return null;
   return (
-    <section
-      {...elementAttributes(rest)}
-      className="mx-auto w-full max-w-page px-page-gutter py-section-block-compact"
-    >
+    <Section {...rest} verticalPadding="compact">
       <div className="grid grid-cols-12 gap-3 max-sm:grid-cols-1">
         {sections.map((section, index) => (
           <article
@@ -57,7 +52,7 @@ function PageValues({ eyebrowSuffix, ...rest }: PageValuesProps) {
           </article>
         ))}
       </div>
-    </section>
+    </Section>
   );
 }
 

--- a/src/sections/page-values/schema.ts
+++ b/src/sections/page-values/schema.ts
@@ -1,9 +1,12 @@
 import { createSchema } from "@weaverse/schema";
 
+import { layoutInputs } from "@/components/section/inputs";
+
 export const schema = createSchema({
   type: "page-values",
   title: "Page values",
   settings: [
+    { group: "Layout", inputs: layoutInputs },
     {
       group: "Content",
       inputs: [

--- a/src/sections/principle-grid/index.tsx
+++ b/src/sections/principle-grid/index.tsx
@@ -1,10 +1,8 @@
 "use client";
 
+import { Section } from "@/components/section";
 import { parseRows } from "../parse";
-import {
-  elementAttributes,
-  type WeaverseElementProps,
-} from "../weaverse-element";
+import type { WeaverseElementProps } from "../weaverse-element";
 
 interface PrincipleGridProps extends WeaverseElementProps {
   /** One `number | title | copy` row per line. Parsed by `./parse`. */
@@ -14,9 +12,10 @@ interface PrincipleGridProps extends WeaverseElementProps {
 /** Materials page: numbered principle cards on a hairline grid. */
 function PrincipleGrid({ principles, ...rest }: PrincipleGridProps) {
   return (
-    <section
-      {...elementAttributes(rest)}
-      className="mx-auto grid w-full max-w-page grid-cols-3 gap-px bg-ink p-px max-md:grid-cols-1"
+    <Section
+      {...rest}
+      verticalPadding="none"
+      containerClassName="grid grid-cols-3 gap-px bg-ink p-px max-md:grid-cols-1"
     >
       {parseRows(principles, 3).map(([number, title, copy]) => (
         <article
@@ -30,7 +29,7 @@ function PrincipleGrid({ principles, ...rest }: PrincipleGridProps) {
           <p>{copy}</p>
         </article>
       ))}
-    </section>
+    </Section>
   );
 }
 

--- a/src/sections/principle-grid/schema.ts
+++ b/src/sections/principle-grid/schema.ts
@@ -1,9 +1,12 @@
 import { createSchema } from "@weaverse/schema";
 
+import { layoutInputs } from "@/components/section/inputs";
+
 export const schema = createSchema({
   type: "principle-grid",
   title: "Principle grid",
   settings: [
+    { group: "Layout", inputs: layoutInputs },
     {
       group: "Content",
       inputs: [

--- a/src/sections/product-spotlight/index.tsx
+++ b/src/sections/product-spotlight/index.tsx
@@ -52,7 +52,6 @@ function ProductSpotlight({
   return (
     <Section
       {...rest}
-      verticalPadding="none"
       containerClassName={cn(
         "grid grid-cols-[minmax(0,1.25fr)_minmax(380px,0.75fr)] gap-0 max-md:grid-cols-1",
         VIEWPORT_SECTION_CLASS,

--- a/src/sections/product-strip/index.tsx
+++ b/src/sections/product-strip/index.tsx
@@ -2,12 +2,10 @@
 
 import Link from "next/link";
 import { ProductCard } from "@/components/product-card";
+import { Section } from "@/components/section";
 import { sectionHeading, textLink } from "@/lib/presentation/variants";
 import type { Product } from "@/lib/storefront/types";
-import {
-  elementAttributes,
-  type WeaverseElementProps,
-} from "../weaverse-element";
+import type { WeaverseElementProps } from "../weaverse-element";
 
 interface ProductStripProps extends WeaverseElementProps {
   eyebrowLabel: string;
@@ -29,10 +27,7 @@ function ProductStrip({
 }: ProductStripProps) {
   const products = loaderData?.products ?? [];
   return (
-    <section
-      {...elementAttributes(rest)}
-      className="mx-auto w-full max-w-page px-page-gutter py-section-block"
-    >
+    <Section {...rest}>
       <header className="mb-11.25 grid grid-cols-feature-row items-end gap-10 max-md:grid-cols-1 max-md:gap-5">
         <div>
           <p className="m-0 max-w-copy-narrow font-field-meta text-ui leading-meta font-medium text-signal-strong tracking-field-meta uppercase">
@@ -49,7 +44,7 @@ function ProductStrip({
           <ProductCard key={product.handle} product={product} />
         ))}
       </div>
-    </section>
+    </Section>
   );
 }
 

--- a/src/sections/product-strip/schema.ts
+++ b/src/sections/product-strip/schema.ts
@@ -1,9 +1,12 @@
 import { createSchema } from "@weaverse/schema";
 
+import { layoutInputs } from "@/components/section/inputs";
+
 export const schema = createSchema({
   type: "product-strip",
   title: "Product strip",
   settings: [
+    { group: "Layout", inputs: layoutInputs },
     {
       group: "Content",
       inputs: [

--- a/src/sections/standard-statement/index.tsx
+++ b/src/sections/standard-statement/index.tsx
@@ -1,11 +1,9 @@
 "use client";
 
+import { Section } from "@/components/section";
 import { eyebrow } from "@/lib/presentation/variants";
 import { parseLines } from "../parse";
-import {
-  elementAttributes,
-  type WeaverseElementProps,
-} from "../weaverse-element";
+import type { WeaverseElementProps } from "../weaverse-element";
 
 interface StandardStatementProps extends WeaverseElementProps {
   eyebrowLabel: string;
@@ -22,10 +20,7 @@ function StandardStatement({
   ...rest
 }: StandardStatementProps) {
   return (
-    <section
-      {...elementAttributes(rest)}
-      className="mx-auto w-full max-w-page px-page-gutter py-section-block"
-    >
+    <Section {...rest}>
       <p className={eyebrow()}>{eyebrowLabel}</p>
       <h2 className="max-w-275 text-balance font-heading text-about-statement leading-display-relaxed">
         {statement}
@@ -35,7 +30,7 @@ function StandardStatement({
           <p key={column}>{column}</p>
         ))}
       </div>
-    </section>
+    </Section>
   );
 }
 

--- a/src/sections/standard-statement/schema.ts
+++ b/src/sections/standard-statement/schema.ts
@@ -1,9 +1,12 @@
 import { createSchema } from "@weaverse/schema";
 
+import { layoutInputs } from "@/components/section/inputs";
+
 export const schema = createSchema({
   type: "standard-statement",
   title: "Standard statement",
   settings: [
+    { group: "Layout", inputs: layoutInputs },
     {
       group: "Content",
       inputs: [

--- a/tests/weaverse-request.test.ts
+++ b/tests/weaverse-request.test.ts
@@ -2,7 +2,10 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
 import type { WeaverseNextLoaderData } from "@weaverse/next";
-import { hasAuthoredSections } from "../src/lib/weaverse/page-payload.ts";
+import {
+  hasAuthoredSections,
+  pageRenders,
+} from "../src/lib/weaverse/page-payload.ts";
 import { buildRequestContext } from "../src/lib/weaverse/request-info.ts";
 
 /**
@@ -139,5 +142,31 @@ describe("buildRequestContext", () => {
       "hiking",
       "climbing",
     ]);
+  });
+});
+
+describe("pageRenders", () => {
+  const page = (items: unknown[]) =>
+    ({ page: { items } }) as unknown as WeaverseNextLoaderData;
+
+  it("finds a component the page places", () => {
+    assert.equal(
+      pageRenders(page([{ id: "a", type: "main-product" }]), "main-product"),
+      true,
+    );
+  });
+
+  it("reports a component the page omits", () => {
+    /* The product route relies on this to keep a buy block on every product
+     * URL when a template has not been seeded, or a merchant removed it. */
+    assert.equal(
+      pageRenders(
+        page([{ id: "a", type: "related-products" }]),
+        "main-product",
+      ),
+      false,
+    );
+    assert.equal(pageRenders(null, "main-product"), false);
+    assert.equal(pageRenders(page([]), "main-product"), false);
   });
 });


### PR DESCRIPTION
Slices 2, 3 and 4 of #72. Stacked on #73 — review that first; this branch shows only what slices 2–4 add.

## 2 — the shared elements finally have somewhere to live

`heading`, `subheading`, `paragraph` and `button` were registered and used in **zero** sections, because no section accepted children. `section-content` is the column that holds them: a section nests one per layout slot and the merchant fills each with elements.

`button` gains a `link` intent rendering the underlined arrow link the sections already use. Without it, every text link would have become a call to action the moment its section was converted.

`field-practice` is the first section converted — four flat strings become elements a merchant can restyle. On `/shop/outerwear` it renders as section → two columns → four elements, each with its own Studio identity.

## The seed script is back, and it is a different thing

Sections are trees now, and changing one strands the flat data a page already holds. Migrating by hand meant a `curl` per section, with ~19 to go, no way to delete the items left behind, and no fallback to catch a mistake.

So a seed file now says **only** which sections a page carries and in what order. The copy, the nested children and their settings expand from each schema's `presets`, recursively:

```json
{ "type": "field-practice" }
```

```
- field-practice
  - section-content
    - subheading  "Field practice"
    - heading     "Let the route set the pace."
  - section-content
    - paragraph   "Efficient movement is not about speed…"
    - button      "More field stories"
```

A shape change is now a `presets` edit plus a re-run, not a hand-written migration. A parent's preset children win over the child schema's own, which is how a two-column band fills each column differently — that was a bug on the first pass, when both columns expanded to the same generic default.

Re-running is the migration path: item ids derive from the position in the tree, so a second run rewrites the same items and re-points the root. Items the new shape no longer uses are left detached, since the Content API has no delete.

## 3 — the product buy block is a section now

Checked first, and it changed the size of this slice: `main-collection`, `main-article` and `main-page` **already existed** as sections. The PDP was the only main page content still rendering outside Weaverse — a 513-line buy block straight from the route, with no way for a merchant to place anything above it.

`main-product` wraps `ProductDetail` **unchanged**. Gallery, colorway and size selection, price and the cart handoff own variant identity and `colorway`/`size` query state and stay in code. That is the ownership rule as decided on the issue: the logic lives in code, the surface is not invisible to Studio.

The route drops from 175 lines to 75. All 146 browser assertions — including every variant, cart and gallery one — stay green.

## 4 — the remaining conversions, and what was left alone

Converted to containers: `editorial-callout` (three columns; its call to action can now be a button or a text link).

Moved onto the shared shell with no markup change, gaining width and padding settings: `page-values`, `product-strip`, `standard-statement`, `numbered-sequence`, `principle-grid`.

Left alone deliberately:

| | Why |
|---|---|
| `home-hero`, `collection-hero`, `page-hero`, `article-header`, `editorial-overlay-hero` | full-bleed heroes with their own grid and min-height; the shell would change their layout |
| `article-body` | renders Shopify blocks verbatim, which is its contract |
| `collection-grid`, `product-tiles`, `stat-band` | data-driven lists with no editorial copy to lift out |
| the `standard-statement` statement itself | uses `text-about-statement`; the `heading` element has no size for it, so converting would change the typography |

The rule applied: lift copy out only where it is genuinely editorial **and** a shared element can express it. Converting the rest mechanically would change the design without giving the merchant anything.

Converting the hero group needs more sizes on the `heading` element first, which touches the type scale and deserves its own issue.

## Verification

```
bun run check               # 371 node + 136 DOM, build, theme, routes — green
bun run smoke:routes        # 35/35
bun run test:browser:static # 146 passed / 10 skipped / 0 failed
```

All eight seeded routes verified rendering with their real `h1` after each reseed.
