### PR TITLE
Convert eleven sections into containers

### DIFF
--- a/src/components/heading/schema.ts
+++ b/src/components/heading/schema.ts
@@ -9,6 +9,12 @@ export const schema = createSchema({
       inputs: [
         { type: "text", name: "content", label: "Text" },
         {
+          type: "text",
+          name: "elementId",
+          label: "Anchor id",
+          helpText: "Optional. Lets a link or a label point at this heading.",
+        },
+        {
           type: "select",
           name: "size",
           label: "Size",

--- a/src/sections/collection-grid/index.tsx
+++ b/src/sections/collection-grid/index.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import Link from "next/link";
+import type { ReactNode } from "react";
 
 import { ProductCard } from "@/components/product-card";
-import { cta, eyebrow, sectionHeading } from "@/lib/presentation/variants";
+import { cta } from "@/lib/presentation/variants";
 import { useStorefrontContext } from "@/lib/weaverse/data-context";
 import {
   elementAttributes,
@@ -11,16 +12,14 @@ import {
 } from "../weaverse-element";
 
 interface CollectionGridProps extends WeaverseElementProps {
-  eyebrowLabel: string;
-  heading: string;
+  children?: ReactNode;
   ctaLabel: string;
   ctaHref: string;
 }
 
 /** Dark product grid for a collection, introduced by a heading and one link. */
 function CollectionGrid({
-  eyebrowLabel,
-  heading,
+  children,
   ctaLabel,
   ctaHref,
   ...rest
@@ -34,10 +33,7 @@ function CollectionGrid({
     >
       <div className="mx-auto w-full max-w-page px-page-gutter">
         <div className="mb-11 flex items-end justify-between gap-7.5 max-sm:flex-col max-sm:items-start">
-          <div>
-            <p className={eyebrow()}>{eyebrowLabel}</p>
-            <h2 className={sectionHeading()}>{heading}</h2>
-          </div>
+          <div>{children}</div>
           <Link className={cta({ intent: "light" })} href={ctaHref}>
             {ctaLabel}
           </Link>

--- a/src/sections/collection-grid/schema.ts
+++ b/src/sections/collection-grid/schema.ts
@@ -3,20 +3,11 @@ import { createSchema } from "@weaverse/schema";
 export const schema = createSchema({
   type: "collection-grid",
   title: "Collection grid",
+  childTypes: ["section-content"],
   settings: [
     {
       group: "Content",
       inputs: [
-        {
-          type: "text",
-          name: "eyebrowLabel",
-          label: "Eyebrow",
-        },
-        {
-          type: "text",
-          name: "heading",
-          label: "Heading",
-        },
         {
           type: "text",
           name: "ctaLabel",
@@ -34,8 +25,15 @@ export const schema = createSchema({
     pages: ["COLLECTION"],
   },
   presets: {
-    eyebrowLabel: "Collection essentials",
-    heading: "A focused kit for a full day out.",
+    children: [
+      {
+        type: "section-content",
+        children: [
+          { type: "subheading", content: "Collection essentials" },
+          { type: "heading", content: "A focused kit for a full day out." },
+        ],
+      },
+    ],
     ctaLabel: "View all equipment",
     ctaHref: "/shop",
   },

--- a/src/sections/collection-index/index.tsx
+++ b/src/sections/collection-index/index.tsx
@@ -2,7 +2,8 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import { eyebrow, sectionHeading } from "@/lib/presentation/variants";
+import type { ReactNode } from "react";
+import { eyebrow } from "@/lib/presentation/variants";
 import type { Collection } from "@/lib/storefront/types";
 import {
   elementAttributes,
@@ -10,16 +11,14 @@ import {
 } from "../weaverse-element";
 
 interface CollectionIndexProps extends WeaverseElementProps {
-  eyebrowLabel: string;
-  heading: string;
+  children?: ReactNode;
   /** Resolved by `./loader` from the merchant's collection selection. */
   loaderData?: { collections: readonly Collection[] };
 }
 
 /** Full-height collection cards, one per movement system. */
 function CollectionIndex({
-  eyebrowLabel,
-  heading,
+  children,
   loaderData,
   ...rest
 }: CollectionIndexProps) {
@@ -30,8 +29,7 @@ function CollectionIndex({
       className="bg-ink pt-20 text-text-inverse"
     >
       <header className="mx-auto w-full max-w-page px-page-gutter pb-11">
-        <p className={eyebrow()}>{eyebrowLabel}</p>
-        <h2 className={sectionHeading()}>{heading}</h2>
+        {children}
       </header>
       <div className="grid grid-cols-3 max-md:grid-cols-1">
         {collections.map((collection) => (

--- a/src/sections/collection-index/schema.ts
+++ b/src/sections/collection-index/schema.ts
@@ -3,22 +3,8 @@ import { createSchema } from "@weaverse/schema";
 export const schema = createSchema({
   type: "collection-index",
   title: "Collection index",
+  childTypes: ["section-content"],
   settings: [
-    {
-      group: "Content",
-      inputs: [
-        {
-          type: "text",
-          name: "eyebrowLabel",
-          label: "Eyebrow",
-        },
-        {
-          type: "text",
-          name: "heading",
-          label: "Heading",
-        },
-      ],
-    },
     {
       group: "Resources",
       inputs: [
@@ -35,7 +21,14 @@ export const schema = createSchema({
     pages: ["INDEX", "CUSTOM"],
   },
   presets: {
-    eyebrowLabel: "Shop by system",
-    heading: "Built separately. Better together.",
+    children: [
+      {
+        type: "section-content",
+        children: [
+          { type: "subheading", content: "Shop by system" },
+          { type: "heading", content: "Built separately. Better together." },
+        ],
+      },
+    ],
   },
 });

--- a/src/sections/editorial-hero/index.tsx
+++ b/src/sections/editorial-hero/index.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import Image from "next/image";
+import type { ReactNode } from "react";
 import { cn } from "@/lib/cn";
-import { eyebrow, sectionHeading } from "@/lib/presentation/variants";
 import type { StorefrontImage } from "@/lib/storefront/types";
 import { weaverseImage } from "@/lib/weaverse/image";
 import {
@@ -11,9 +11,7 @@ import {
 } from "../weaverse-element";
 
 interface EditorialHeroProps extends WeaverseElementProps {
-  eyebrowLabel: string;
-  heading: string;
-  lede: string;
+  children?: ReactNode;
   /** A Builder image value, a StorefrontImage, or nothing. */
   image?: StorefrontImage | unknown;
   /** Which column the image occupies on desktop. Defaults to `right`. */
@@ -25,9 +23,7 @@ interface EditorialHeroProps extends WeaverseElementProps {
  * Used by the About and Materials custom pages.
  */
 function EditorialHero({
-  eyebrowLabel,
-  heading,
-  lede,
+  children,
   image,
   imageSide = "right",
   ...rest
@@ -48,13 +44,7 @@ function EditorialHero({
           imageFirst && "order-2 max-md:order-1",
         )}
       >
-        <p className={eyebrow()}>{eyebrowLabel}</p>
-        <h1 className={cn(sectionHeading({ size: "heroWide" }), "mt-5 mb-7.5")}>
-          {heading}
-        </h1>
-        <p className="max-w-lede text-lede leading-lede text-text-muted">
-          {lede}
-        </p>
+        {children}
       </div>
       {resolved === null ? null : (
         <Image

--- a/src/sections/editorial-hero/schema.ts
+++ b/src/sections/editorial-hero/schema.ts
@@ -1,37 +1,21 @@
 import { createSchema } from "@weaverse/schema";
 
+import { layoutInputs } from "@/components/section/inputs";
+
 export const schema = createSchema({
   type: "editorial-hero",
   title: "Editorial hero",
+  childTypes: ["section-content"],
+  enabledOn: { pages: ["PAGE", "CUSTOM"] },
   settings: [
     {
       group: "Content",
       inputs: [
-        {
-          type: "text",
-          name: "eyebrowLabel",
-          label: "Eyebrow",
-        },
-        {
-          type: "text",
-          name: "heading",
-          label: "Heading",
-        },
-        {
-          type: "textarea",
-          name: "lede",
-          label: "Lede",
-        },
-        {
-          type: "image",
-          name: "image",
-          label: "Image",
-        },
+        { type: "image", name: "image", label: "Image" },
         {
           type: "select",
           name: "imageSide",
           label: "Image side",
-          defaultValue: "right",
           configs: {
             options: [
               { value: "left", label: "Left" },
@@ -41,14 +25,29 @@ export const schema = createSchema({
         },
       ],
     },
+    { group: "Layout", inputs: layoutInputs },
   ],
-  enabledOn: {
-    pages: ["PAGE", "CUSTOM"],
-  },
   presets: {
-    eyebrowLabel: "Custom page / About Forward",
-    heading: "Make less equipment. Make every piece matter.",
-    lede: "Forward is built around complete movement systems rather than seasonal noise: fewer products, clearer jobs, longer useful lives.",
     imageSide: "right",
+    children: [
+      {
+        type: "section-content",
+        justify: "center",
+        children: [
+          { type: "subheading", content: "Custom page / About Forward" },
+          {
+            type: "heading",
+            as: "h1",
+            size: "heroWide",
+            content: "Make less equipment. Make every piece matter.",
+          },
+          {
+            type: "paragraph",
+            content:
+              "Forward is built around complete movement systems rather than seasonal noise: fewer products, clearer jobs, longer useful lives.",
+          },
+        ],
+      },
+    ],
   },
 });

--- a/src/sections/editorial-hero/schema.ts
+++ b/src/sections/editorial-hero/schema.ts
@@ -1,7 +1,5 @@
 import { createSchema } from "@weaverse/schema";
 
-import { layoutInputs } from "@/components/section/inputs";
-
 export const schema = createSchema({
   type: "editorial-hero",
   title: "Editorial hero",
@@ -25,7 +23,6 @@ export const schema = createSchema({
         },
       ],
     },
-    { group: "Layout", inputs: layoutInputs },
   ],
   presets: {
     imageSide: "right",

--- a/src/sections/editorial-overlay-hero/index.tsx
+++ b/src/sections/editorial-overlay-hero/index.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import Image from "next/image";
-import { cn } from "@/lib/cn";
-import { eyebrow, sectionHeading } from "@/lib/presentation/variants";
+import type { ReactNode } from "react";
 import type { StorefrontImage } from "@/lib/storefront/types";
 import { weaverseImage } from "@/lib/weaverse/image";
 import {
@@ -11,18 +10,14 @@ import {
 } from "../weaverse-element";
 
 interface EditorialOverlayHeroProps extends WeaverseElementProps {
-  eyebrowLabel: string;
-  heading: string;
-  lede: string;
+  children?: ReactNode;
   /** A Builder image value, a StorefrontImage, or nothing. */
   image?: StorefrontImage | unknown;
 }
 
 /** Full-bleed hero: copy sits over a darkened cover image. */
 function EditorialOverlayHero({
-  eyebrowLabel,
-  heading,
-  lede,
+  children,
   image,
   ...rest
 }: EditorialOverlayHeroProps) {
@@ -45,11 +40,7 @@ function EditorialOverlayHero({
         />
       )}
       <div className="relative z-1 max-w-205 p-[clamp(70px,9vw,150px)] max-md:px-page-gutter max-md:py-16.25">
-        <p className={eyebrow()}>{eyebrowLabel}</p>
-        <h1 className={cn(sectionHeading({ size: "heroWide" }), "mt-5 mb-7.5")}>
-          {heading}
-        </h1>
-        <p className="max-w-state text-control-lg">{lede}</p>
+        {children}
       </div>
     </section>
   );

--- a/src/sections/editorial-overlay-hero/schema.ts
+++ b/src/sections/editorial-overlay-hero/schema.ts
@@ -1,7 +1,5 @@
 import { createSchema } from "@weaverse/schema";
 
-import { layoutInputs } from "@/components/section/inputs";
-
 export const schema = createSchema({
   type: "editorial-overlay-hero",
   title: "Editorial overlay hero",
@@ -12,7 +10,6 @@ export const schema = createSchema({
       group: "Content",
       inputs: [{ type: "image", name: "image", label: "Image" }],
     },
-    { group: "Layout", inputs: layoutInputs },
   ],
   presets: {
     children: [

--- a/src/sections/editorial-overlay-hero/schema.ts
+++ b/src/sections/editorial-overlay-hero/schema.ts
@@ -1,41 +1,39 @@
 import { createSchema } from "@weaverse/schema";
 
+import { layoutInputs } from "@/components/section/inputs";
+
 export const schema = createSchema({
   type: "editorial-overlay-hero",
   title: "Editorial overlay hero",
+  childTypes: ["section-content"],
+  enabledOn: { pages: ["PAGE", "CUSTOM"] },
   settings: [
     {
       group: "Content",
-      inputs: [
-        {
-          type: "text",
-          name: "eyebrowLabel",
-          label: "Eyebrow",
-        },
-        {
-          type: "text",
-          name: "heading",
-          label: "Heading",
-        },
-        {
-          type: "textarea",
-          name: "lede",
-          label: "Lede",
-        },
-        {
-          type: "image",
-          name: "image",
-          label: "Image",
-        },
-      ],
+      inputs: [{ type: "image", name: "image", label: "Image" }],
     },
+    { group: "Layout", inputs: layoutInputs },
   ],
-  enabledOn: {
-    pages: ["PAGE", "CUSTOM"],
-  },
   presets: {
-    eyebrowLabel: "Custom page / Field testing",
-    heading: "Tested where it is used.",
-    lede: "Every product is carried through real days out before it is signed off: wet, cold, loaded, and long.",
+    children: [
+      {
+        type: "section-content",
+        justify: "end",
+        children: [
+          { type: "subheading", content: "Custom page / Field testing" },
+          {
+            type: "heading",
+            as: "h1",
+            size: "heroWide",
+            content: "Tested where it is used.",
+          },
+          {
+            type: "paragraph",
+            content:
+              "Every product is carried through real days out before it is signed off: wet, cold, loaded, and long.",
+          },
+        ],
+      },
+    ],
   },
 });

--- a/src/sections/featured-products/index.tsx
+++ b/src/sections/featured-products/index.tsx
@@ -1,29 +1,20 @@
 "use client";
 
-import Link from "next/link";
+import type { ReactNode } from "react";
 import { ProductCard } from "@/components/product-card";
 import { Section } from "@/components/section";
-import { eyebrow, sectionHeading, textLink } from "@/lib/presentation/variants";
 import type { Product } from "@/lib/storefront/types";
 import type { WeaverseElementProps } from "../weaverse-element";
 
 interface FeaturedProductsProps extends WeaverseElementProps {
-  eyebrowLabel: string;
-  heading: string;
-  body: string;
-  linkLabel: string;
-  linkHref: string;
+  children?: ReactNode;
   /** Resolved by `./loader` from the merchant's product selection. */
   loaderData?: { products: readonly Product[] };
 }
 
 /** A four-up product grid introduced by a heading, body copy, and one link. */
 function FeaturedProducts({
-  eyebrowLabel,
-  heading,
-  body,
-  linkLabel,
-  linkHref,
+  children,
   loaderData,
   ...rest
 }: FeaturedProductsProps) {
@@ -31,16 +22,7 @@ function FeaturedProducts({
   return (
     <Section {...rest} aria-labelledby="home-featured-title">
       <header className="mb-11.25 grid grid-cols-feature-row items-end gap-10 max-md:grid-cols-1 max-md:gap-5">
-        <div>
-          <p className={eyebrow()}>{eyebrowLabel}</p>
-          <h2 className={sectionHeading()} id="home-featured-title">
-            {heading}
-          </h2>
-        </div>
-        <p className="m-0 max-w-copy-narrow">{body}</p>
-        <Link className={textLink()} href={linkHref}>
-          {linkLabel}
-        </Link>
+        {children}
       </header>
       <div className="grid grid-cols-4 gap-4.5 max-md:grid-cols-2 max-sm:gap-2.5">
         {products.map((product, index) => (

--- a/src/sections/featured-products/schema.ts
+++ b/src/sections/featured-products/schema.ts
@@ -5,38 +5,9 @@ import { layoutInputs } from "@/components/section/inputs";
 export const schema = createSchema({
   type: "featured-products",
   title: "Featured products",
+  childTypes: ["section-content"],
   settings: [
     { group: "Layout", inputs: layoutInputs },
-    {
-      group: "Content",
-      inputs: [
-        {
-          type: "text",
-          name: "eyebrowLabel",
-          label: "Eyebrow",
-        },
-        {
-          type: "text",
-          name: "heading",
-          label: "Heading",
-        },
-        {
-          type: "textarea",
-          name: "body",
-          label: "Body",
-        },
-        {
-          type: "text",
-          name: "linkLabel",
-          label: "Link label",
-        },
-        {
-          type: "url",
-          name: "linkHref",
-          label: "Link target",
-        },
-      ],
-    },
     {
       group: "Resources",
       inputs: [
@@ -53,10 +24,40 @@ export const schema = createSchema({
     pages: ["INDEX", "CUSTOM"],
   },
   presets: {
-    eyebrowLabel: "New field rotation",
-    heading: "Start with the core four.",
-    body: "A weather layer, breathable midlayer, close-body carry, and trail shoe form the shortest route to a complete Forward system.",
-    linkLabel: "Shop the full catalog",
-    linkHref: "/shop",
+    children: [
+      {
+        type: "section-content",
+        children: [
+          { type: "subheading", content: "New field rotation" },
+          {
+            type: "heading",
+            elementId: "home-featured-title",
+            content: "Start with the core four.",
+          },
+        ],
+      },
+      {
+        type: "section-content",
+        children: [
+          {
+            type: "paragraph",
+            content:
+              "A weather layer, breathable midlayer, close-body carry, and trail shoe form the shortest route to a complete Forward system.",
+          },
+        ],
+      },
+      {
+        type: "section-content",
+        justify: "end",
+        children: [
+          {
+            type: "button",
+            label: "Shop the full catalog",
+            href: "/shop",
+            intent: "link",
+          },
+        ],
+      },
+    ],
   },
 });

--- a/src/sections/home-hero/index.tsx
+++ b/src/sections/home-hero/index.tsx
@@ -2,14 +2,7 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import { cn } from "@/lib/cn";
-import {
-  cta,
-  eyebrow,
-  LEDE_CLASS,
-  sectionHeading,
-  textLink,
-} from "@/lib/presentation/variants";
+import type { ReactNode } from "react";
 import type { Product, StorefrontImage } from "@/lib/storefront/types";
 import { weaverseImage } from "@/lib/weaverse/image";
 import { parseRows } from "../parse";
@@ -19,13 +12,7 @@ import {
 } from "../weaverse-element";
 
 interface HomeHeroProps extends WeaverseElementProps {
-  eyebrowLabel: string;
-  heading: string;
-  lede: string;
-  primaryCtaLabel: string;
-  primaryCtaHref: string;
-  secondaryCtaLabel: string;
-  secondaryCtaHref: string;
+  children?: ReactNode;
   /** One `value | label` pair per line. Parsed by `../parse`. */
   stats: string;
   /** A Builder image value, a StorefrontImage, or nothing. */
@@ -36,13 +23,7 @@ interface HomeHeroProps extends WeaverseElementProps {
 
 /** Home hero: split copy and image, with a summary stat row and image badge. */
 function HomeHero({
-  eyebrowLabel,
-  heading,
-  lede,
-  primaryCtaLabel,
-  primaryCtaHref,
-  secondaryCtaLabel,
-  secondaryCtaHref,
+  children,
   stats,
   image,
   loaderData,
@@ -57,27 +38,7 @@ function HomeHero({
       className="grid min-h-[calc(100svh_-_var(--spacing-header))] grid-cols-[minmax(390px,0.78fr)_minmax(0,1.22fr)] bg-ink text-text-inverse max-md:min-h-[calc(100svh_-_var(--spacing-header-compact))] max-md:grid-cols-1"
     >
       <div className="flex flex-col justify-center p-[clamp(48px,6vw,100px)] max-md:px-page-gutter max-md:py-13.75">
-        <p className={eyebrow()}>{eyebrowLabel}</p>
-        <h1
-          className={cn(
-            sectionHeading({ size: "hero" }),
-            "mt-5.5 mb-7 max-w-190",
-          )}
-          id="home-hero-title"
-        >
-          {heading}
-        </h1>
-        <p className={cn(LEDE_CLASS, "max-w-142.5 text-text-dark-subtle")}>
-          {lede}
-        </p>
-        <div className="mt-8.5 flex flex-wrap items-center gap-6">
-          <Link className={cta({ intent: "signal" })} href={primaryCtaHref}>
-            {primaryCtaLabel}
-          </Link>
-          <Link className={textLink()} href={secondaryCtaHref}>
-            {secondaryCtaLabel}
-          </Link>
-        </div>
+        {children}
         <dl className="mt-auto grid grid-cols-3 border-border-dark-subtle border-t pt-9 max-md:mt-11.25">
           {parseRows(stats, 2).map(([value, label]) => (
             <div className="grid gap-1.5" key={label}>

--- a/src/sections/home-hero/schema.ts
+++ b/src/sections/home-hero/schema.ts
@@ -3,45 +3,11 @@ import { createSchema } from "@weaverse/schema";
 export const schema = createSchema({
   type: "home-hero",
   title: "Home hero",
+  childTypes: ["section-content"],
   settings: [
     {
       group: "Content",
       inputs: [
-        {
-          type: "text",
-          name: "eyebrowLabel",
-          label: "Eyebrow",
-        },
-        {
-          type: "text",
-          name: "heading",
-          label: "Heading",
-        },
-        {
-          type: "textarea",
-          name: "lede",
-          label: "Lede",
-        },
-        {
-          type: "text",
-          name: "primaryCtaLabel",
-          label: "Primary CTA label",
-        },
-        {
-          type: "url",
-          name: "primaryCtaHref",
-          label: "Primary CTA link",
-        },
-        {
-          type: "text",
-          name: "secondaryCtaLabel",
-          label: "Secondary CTA label",
-        },
-        {
-          type: "url",
-          name: "secondaryCtaHref",
-          label: "Secondary CTA link",
-        },
         {
           type: "textarea",
           name: "stats",
@@ -70,13 +36,40 @@ export const schema = createSchema({
     pages: ["INDEX"],
   },
   presets: {
-    eyebrowLabel: "Forward / Field equipment 2026",
-    heading: "Equipment for weather that changes the plan.",
-    lede: "Layerable apparel, precise footwear, and low-profile carry systems made to move together.",
-    primaryCtaLabel: "Shop all equipment",
-    primaryCtaHref: "/shop",
-    secondaryCtaLabel: "How we test",
-    secondaryCtaHref: "/field-testing",
+    children: [
+      {
+        type: "section-content",
+        justify: "center",
+        children: [
+          { type: "subheading", content: "Forward / Field equipment 2026" },
+          {
+            type: "heading",
+            as: "h1",
+            size: "hero",
+            /* The hero section is labelled by this heading. */
+            elementId: "home-hero-title",
+            content: "Equipment for weather that changes the plan.",
+          },
+          {
+            type: "paragraph",
+            content:
+              "Layerable apparel, precise footwear, and low-profile carry systems made to move together.",
+          },
+          {
+            type: "button",
+            label: "Shop all equipment",
+            href: "/shop",
+            intent: "signal",
+          },
+          {
+            type: "button",
+            label: "How we test",
+            href: "/field-testing",
+            intent: "link",
+          },
+        ],
+      },
+    ],
     stats: "3 | Systems\n9 | Core objects\nFor life | Repair",
   },
 });

--- a/src/sections/main-product/schema.ts
+++ b/src/sections/main-product/schema.ts
@@ -1,10 +1,12 @@
 import { createSchema } from "@weaverse/schema";
 
+import { layoutInputs } from "@/components/section/inputs";
+
 export const schema = createSchema({
   type: "main-product",
   title: "Main product",
   limit: 1,
   enabledOn: { pages: ["PRODUCT"] },
-  settings: [],
+  settings: [{ group: "Layout", inputs: layoutInputs }],
   presets: {},
 });

--- a/src/sections/main-product/schema.ts
+++ b/src/sections/main-product/schema.ts
@@ -1,12 +1,13 @@
 import { createSchema } from "@weaverse/schema";
 
-import { layoutInputs } from "@/components/section/inputs";
-
 export const schema = createSchema({
   type: "main-product",
   title: "Main product",
   limit: 1,
   enabledOn: { pages: ["PRODUCT"] },
-  settings: [{ group: "Layout", inputs: layoutInputs }],
+  /* No settings. The buy block's behaviour is variant identity, query state
+   * and the cart handoff, none of which is a merchant's to configure; what is
+   * theirs is where the block sits among the product page's sections. */
+  settings: [],
   presets: {},
 });

--- a/src/sections/material-standard/index.tsx
+++ b/src/sections/material-standard/index.tsx
@@ -1,13 +1,7 @@
 "use client";
 
 import Image from "next/image";
-import Link from "next/link";
-import {
-  cta,
-  eyebrow,
-  sectionHeading,
-  textLink,
-} from "@/lib/presentation/variants";
+import type { ReactNode } from "react";
 import type { StorefrontImage } from "@/lib/storefront/types";
 import { weaverseImage } from "@/lib/weaverse/image";
 import {
@@ -16,29 +10,13 @@ import {
 } from "../weaverse-element";
 
 interface MaterialStandardProps extends WeaverseElementProps {
-  eyebrowLabel: string;
-  heading: string;
-  body: string;
-  primaryCtaLabel: string;
-  primaryCtaHref: string;
-  secondaryCtaLabel: string;
-  secondaryCtaHref: string;
+  children?: ReactNode;
   /** A Builder image value, a StorefrontImage, or nothing. */
   image?: StorefrontImage | unknown;
 }
 
 /** Dark editorial band pairing the material story with a wide image. */
-function MaterialStandard({
-  eyebrowLabel,
-  heading,
-  body,
-  primaryCtaLabel,
-  primaryCtaHref,
-  secondaryCtaLabel,
-  secondaryCtaHref,
-  image,
-  ...rest
-}: MaterialStandardProps) {
+function MaterialStandard({ children, image, ...rest }: MaterialStandardProps) {
   const resolvedImage = weaverseImage(image);
   return (
     <section
@@ -46,19 +24,7 @@ function MaterialStandard({
       className="grid grid-cols-split-85 bg-ink text-text-inverse max-md:grid-cols-1"
     >
       <div className="flex flex-col justify-center p-[clamp(48px,7vw,110px)]">
-        <p className={eyebrow()}>{eyebrowLabel}</p>
-        <h2 className={sectionHeading()}>{heading}</h2>
-        <p className="mb-prose-paragraph max-w-state text-copy-lg text-text-dark-subtle">
-          {body}
-        </p>
-        <div className="mt-8.5 flex flex-wrap items-center gap-6">
-          <Link className={cta({ intent: "light" })} href={primaryCtaHref}>
-            {primaryCtaLabel}
-          </Link>
-          <Link className={textLink()} href={secondaryCtaHref}>
-            {secondaryCtaLabel}
-          </Link>
-        </div>
+        {children}
       </div>
       {resolvedImage === null ? null : (
         <Image

--- a/src/sections/material-standard/schema.ts
+++ b/src/sections/material-standard/schema.ts
@@ -1,65 +1,46 @@
 import { createSchema } from "@weaverse/schema";
 
+import { layoutInputs } from "@/components/section/inputs";
+
 export const schema = createSchema({
   type: "material-standard",
   title: "Material standard",
+  childTypes: ["section-content"],
+  enabledOn: { pages: ["INDEX", "CUSTOM"] },
   settings: [
     {
       group: "Content",
-      inputs: [
-        {
-          type: "text",
-          name: "eyebrowLabel",
-          label: "Eyebrow",
-        },
-        {
-          type: "text",
-          name: "heading",
-          label: "Heading",
-        },
-        {
-          type: "textarea",
-          name: "body",
-          label: "Body",
-        },
-        {
-          type: "text",
-          name: "primaryCtaLabel",
-          label: "Primary CTA label",
-        },
-        {
-          type: "url",
-          name: "primaryCtaHref",
-          label: "Primary CTA link",
-        },
-        {
-          type: "text",
-          name: "secondaryCtaLabel",
-          label: "Secondary CTA label",
-        },
-        {
-          type: "url",
-          name: "secondaryCtaHref",
-          label: "Secondary CTA link",
-        },
-        {
-          type: "image",
-          name: "image",
-          label: "Image",
-        },
-      ],
+      inputs: [{ type: "image", name: "image", label: "Image" }],
     },
+    { group: "Layout", inputs: layoutInputs },
   ],
-  enabledOn: {
-    pages: ["INDEX", "CUSTOM"],
-  },
   presets: {
-    eyebrowLabel: "Material standard",
-    heading: "Fewer materials. Better understood.",
-    body: "Every fabric, foam, buckle, and compound is selected around useful life, field repair, and performance you can actually feel.",
-    primaryCtaLabel: "Explore materials",
-    primaryCtaHref: "/materials",
-    secondaryCtaLabel: "About Forward",
-    secondaryCtaHref: "/about",
+    children: [
+      {
+        type: "section-content",
+        justify: "center",
+        children: [
+          { type: "subheading", content: "Material standard" },
+          { type: "heading", content: "Fewer materials. Better understood." },
+          {
+            type: "paragraph",
+            content:
+              "Every fabric, foam, buckle, and compound is selected around useful life, field repair, and performance you can actually feel.",
+          },
+          {
+            type: "button",
+            label: "Explore materials",
+            href: "/materials",
+            intent: "light",
+          },
+          {
+            type: "button",
+            label: "About Forward",
+            href: "/about",
+            intent: "link",
+          },
+        ],
+      },
+    ],
   },
 });

--- a/src/sections/material-standard/schema.ts
+++ b/src/sections/material-standard/schema.ts
@@ -1,7 +1,5 @@
 import { createSchema } from "@weaverse/schema";
 
-import { layoutInputs } from "@/components/section/inputs";
-
 export const schema = createSchema({
   type: "material-standard",
   title: "Material standard",
@@ -12,7 +10,6 @@ export const schema = createSchema({
       group: "Content",
       inputs: [{ type: "image", name: "image", label: "Image" }],
     },
-    { group: "Layout", inputs: layoutInputs },
   ],
   presets: {
     children: [

--- a/src/sections/numbered-sequence/index.tsx
+++ b/src/sections/numbered-sequence/index.tsx
@@ -1,7 +1,8 @@
 "use client";
 
+import type { ReactNode } from "react";
+
 import { Section } from "@/components/section";
-import { eyebrow, sectionHeading } from "@/lib/presentation/variants";
 import { parseRows } from "../parse";
 import type { WeaverseElementProps } from "../weaverse-element";
 
@@ -10,28 +11,19 @@ const SEQUENCE_STEP_CLASS =
   "grid grid-cols-[65px_1fr] gap-5 border-border-subtle border-b py-7";
 
 interface NumberedSequenceProps extends WeaverseElementProps {
-  eyebrowLabel: string;
-  heading: string;
+  children?: ReactNode;
   /** One `number | title | copy` row per line. Parsed by `./parse`. */
   steps: string;
 }
 
 /** An ordered protocol rendered as a numbered list beside its heading. */
-function NumberedSequence({
-  eyebrowLabel,
-  heading,
-  steps,
-  ...rest
-}: NumberedSequenceProps) {
+function NumberedSequence({ children, steps, ...rest }: NumberedSequenceProps) {
   return (
     <Section
       {...rest}
       containerClassName="grid grid-cols-split-70 gap-20 max-md:grid-cols-1"
     >
-      <header>
-        <p className={eyebrow()}>{eyebrowLabel}</p>
-        <h2 className={sectionHeading()}>{heading}</h2>
-      </header>
+      <header>{children}</header>
       <ol className="m-0 list-none border-border-subtle border-t p-0">
         {parseRows(steps, 3).map(([number, title, copy]) => (
           <li className={SEQUENCE_STEP_CLASS} key={number}>

--- a/src/sections/numbered-sequence/schema.ts
+++ b/src/sections/numbered-sequence/schema.ts
@@ -5,21 +5,12 @@ import { layoutInputs } from "@/components/section/inputs";
 export const schema = createSchema({
   type: "numbered-sequence",
   title: "Numbered sequence",
+  childTypes: ["section-content"],
   settings: [
     { group: "Layout", inputs: layoutInputs },
     {
       group: "Content",
       inputs: [
-        {
-          type: "text",
-          name: "eyebrowLabel",
-          label: "Eyebrow",
-        },
-        {
-          type: "text",
-          name: "heading",
-          label: "Heading",
-        },
         {
           type: "textarea",
           name: "steps",
@@ -32,8 +23,15 @@ export const schema = createSchema({
     pages: ["PAGE", "CUSTOM"],
   },
   presets: {
-    eyebrowLabel: "How we test",
-    heading: "Four passes before a product ships.",
+    children: [
+      {
+        type: "section-content",
+        children: [
+          { type: "subheading", content: "How we test" },
+          { type: "heading", content: "Four passes before a product ships." },
+        ],
+      },
+    ],
     steps:
       "Define the job | We write down the day the product has to survive before we draw anything.\nBuild to the job | Patterns, materials, and hardware are specified against that day, not against a trend.\nCarry it out | Prototypes go out wet, cold, loaded, and long, with the people who will use them.\nSign it off | A product ships only when the failure notes stop being about the product.",
   },

--- a/src/sections/related-products/index.tsx
+++ b/src/sections/related-products/index.tsx
@@ -1,31 +1,24 @@
 "use client";
 
+import type { ReactNode } from "react";
+
 import { ProductCard } from "@/components/product-card";
 import { Section } from "@/components/section";
-import { eyebrow, sectionHeading } from "@/lib/presentation/variants";
 import { useStorefrontContext } from "@/lib/weaverse/data-context";
 import type { WeaverseElementProps } from "../weaverse-element";
 
 interface RelatedProductsProps extends WeaverseElementProps {
-  eyebrowLabel: string;
-  heading: string;
+  children?: ReactNode;
 }
 
 /** Products that complete the system around the one being viewed. */
-function RelatedProducts({
-  eyebrowLabel,
-  heading,
-  ...rest
-}: RelatedProductsProps) {
+function RelatedProducts({ children, ...rest }: RelatedProductsProps) {
   const { products: contextProducts } = useStorefrontContext();
   const products = contextProducts ?? [];
   return (
     <Section {...rest}>
       <div className="mb-11 flex items-end justify-between gap-7.5 max-sm:flex-col max-sm:items-start">
-        <div>
-          <p className={eyebrow()}>{eyebrowLabel}</p>
-          <h2 className={sectionHeading()}>{heading}</h2>
-        </div>
+        <div>{children}</div>
       </div>
       <div className="grid grid-cols-4 gap-4.5 max-lg:grid-cols-2 max-sm:grid-cols-2 max-sm:gap-2.5">
         {products.map((product) => (

--- a/src/sections/related-products/schema.ts
+++ b/src/sections/related-products/schema.ts
@@ -5,29 +5,20 @@ import { layoutInputs } from "@/components/section/inputs";
 export const schema = createSchema({
   type: "related-products",
   title: "Related products",
-  settings: [
-    { group: "Layout", inputs: layoutInputs },
-    {
-      group: "Content",
-      inputs: [
-        {
-          type: "text",
-          name: "eyebrowLabel",
-          label: "Eyebrow",
-        },
-        {
-          type: "text",
-          name: "heading",
-          label: "Heading",
-        },
-      ],
-    },
-  ],
+  childTypes: ["section-content"],
+  settings: [{ group: "Layout", inputs: layoutInputs }],
   enabledOn: {
     pages: ["PRODUCT"],
   },
   presets: {
-    eyebrowLabel: "Works well with",
-    heading: "Complete the field system.",
+    children: [
+      {
+        type: "section-content",
+        children: [
+          { type: "subheading", content: "Works well with" },
+          { type: "heading", content: "Complete the field system." },
+        ],
+      },
+    ],
   },
 });

--- a/src/sections/standard-statement/index.tsx
+++ b/src/sections/standard-statement/index.tsx
@@ -1,31 +1,26 @@
 "use client";
 
+import type { ReactNode } from "react";
+
 import { Section } from "@/components/section";
-import { cn } from "@/lib/cn";
-import { eyebrow, sectionHeading } from "@/lib/presentation/variants";
 import { parseLines } from "../parse";
 import type { WeaverseElementProps } from "../weaverse-element";
 
 interface StandardStatementProps extends WeaverseElementProps {
-  eyebrowLabel: string;
-  statement: string;
+  children?: ReactNode;
   /** One column per line. Parsed by `./parse`. */
   columns: string;
 }
 
 /** A single wide statement expanded by a row of supporting paragraphs. */
 function StandardStatement({
-  eyebrowLabel,
-  statement,
+  children,
   columns,
   ...rest
 }: StandardStatementProps) {
   return (
     <Section {...rest}>
-      <p className={eyebrow()}>{eyebrowLabel}</p>
-      <h2 className={cn(sectionHeading({ size: "statement" }), "max-w-275")}>
-        {statement}
-      </h2>
+      {children}
       <div className="mt-17.5 grid grid-cols-3 gap-10 text-copy-lg max-md:mt-8.75 max-md:grid-cols-1 max-md:gap-2.5">
         {parseLines(columns).map((column) => (
           <p key={column}>{column}</p>

--- a/src/sections/standard-statement/schema.ts
+++ b/src/sections/standard-statement/schema.ts
@@ -5,21 +5,12 @@ import { layoutInputs } from "@/components/section/inputs";
 export const schema = createSchema({
   type: "standard-statement",
   title: "Standard statement",
+  childTypes: ["section-content"],
   settings: [
     { group: "Layout", inputs: layoutInputs },
     {
       group: "Content",
       inputs: [
-        {
-          type: "text",
-          name: "eyebrowLabel",
-          label: "Eyebrow",
-        },
-        {
-          type: "textarea",
-          name: "statement",
-          label: "Statement",
-        },
         {
           type: "textarea",
           name: "columns",
@@ -32,9 +23,20 @@ export const schema = createSchema({
     pages: ["PAGE", "CUSTOM"],
   },
   presets: {
-    eyebrowLabel: "The Forward standard",
-    statement:
-      "Useful over novel. Repairable over disposable. Quiet over loud.",
+    children: [
+      {
+        type: "section-content",
+        children: [
+          { type: "subheading", content: "The Forward standard" },
+          {
+            type: "heading",
+            size: "statement",
+            content:
+              "Useful over novel. Repairable over disposable. Quiet over loud.",
+          },
+        ],
+      },
+    ],
     columns:
       "We begin with the work a product must do, then remove anything that does not improve movement, protection, carry, or recovery.\nMaterials are selected for known performance and honest aging. A worn product should carry evidence of use\u2014not become obsolete.\nEvery core object belongs to a system, so layers and equipment earn their place together instead of competing for attention.",
   },

--- a/src/sections/system-manifest/index.tsx
+++ b/src/sections/system-manifest/index.tsx
@@ -2,17 +2,16 @@
 
 import Image from "next/image";
 import Link from "next/link";
+import type { ReactNode } from "react";
 import { Section } from "@/components/section";
-import { eyebrow, textLink } from "@/lib/presentation/variants";
+import { textLink } from "@/lib/presentation/variants";
 import type { StorefrontImage } from "@/lib/storefront/types";
 import { useStorefrontContext } from "@/lib/weaverse/data-context";
 import { weaverseImage } from "@/lib/weaverse/image";
 import type { WeaverseElementProps } from "../weaverse-element";
 
 interface SystemManifestProps extends WeaverseElementProps {
-  eyebrowLabel: string;
-  heading: string;
-  body: string;
+  children?: ReactNode;
   /** A Builder image value, a StorefrontImage, or nothing. */
   image?: StorefrontImage | unknown;
   linkLabel: string;
@@ -22,9 +21,7 @@ interface SystemManifestProps extends WeaverseElementProps {
 
 /** An offset image beside the system story and its product manifest list. */
 function SystemManifest({
-  eyebrowLabel,
-  heading,
-  body,
+  children,
   image,
   linkLabel,
   linkHref,
@@ -50,13 +47,7 @@ function SystemManifest({
           </div>
         )}
         <div>
-          <p className={eyebrow()}>{eyebrowLabel}</p>
-          <h2 className="mb-7 text-balance font-heading text-heading-2 leading-heading font-medium tracking-heading">
-            {heading}
-          </h2>
-          <p className="mb-7.5 max-w-lede text-lede leading-lede text-text-muted">
-            {body}
-          </p>
+          {children}
           <ul className="my-8 list-none border-border-subtle border-t p-0">
             {products.map((product) => (
               <li

--- a/src/sections/system-manifest/schema.ts
+++ b/src/sections/system-manifest/schema.ts
@@ -5,26 +5,12 @@ import { layoutInputs } from "@/components/section/inputs";
 export const schema = createSchema({
   type: "system-manifest",
   title: "System manifest",
+  childTypes: ["section-content"],
   settings: [
     { group: "Layout", inputs: layoutInputs },
     {
       group: "Content",
       inputs: [
-        {
-          type: "text",
-          name: "eyebrowLabel",
-          label: "Eyebrow",
-        },
-        {
-          type: "text",
-          name: "heading",
-          label: "Heading",
-        },
-        {
-          type: "textarea",
-          name: "body",
-          label: "Body",
-        },
         {
           type: "image",
           name: "image",
@@ -47,9 +33,23 @@ export const schema = createSchema({
     pages: ["COLLECTION"],
   },
   presets: {
-    eyebrowLabel: "The system",
-    heading: "Prepare for change, not every possibility.",
-    body: "Start with a layer that moves moisture, add warmth you can vent, and finish with a shell that packs small enough to bring every time. This kit is built to work as one system.",
+    children: [
+      {
+        type: "section-content",
+        children: [
+          { type: "subheading", content: "The system" },
+          {
+            type: "heading",
+            content: "Prepare for change, not every possibility.",
+          },
+          {
+            type: "paragraph",
+            content:
+              "Start with a layer that moves moisture, add warmth you can vent, and finish with a shell that packs small enough to bring every time. This kit is built to work as one system.",
+          },
+        ],
+      },
+    ],
     linkLabel: "Read the field note",
     linkHref: "/journal",
   },

--- a/src/sections/weaverse-element.ts
+++ b/src/sections/weaverse-element.ts
@@ -34,6 +34,13 @@ export function elementAttributes(
   props: WeaverseElementProps,
 ): Record<string, string> {
   const attributes: Record<string, string> = {};
+  /* The runtime keeps `id` for the item's own identity, so an authored anchor
+   * has to travel under its own name. It matters beyond anchors: a section
+   * labelled by its heading needs that heading to carry a stable id, and the
+   * heading is a child now. */
+  if (typeof props.elementId === "string" && props.elementId.length > 0) {
+    attributes.id = props.elementId;
+  }
   const forwarded = Object.keys(props).filter(
     (key) =>
       key === "data-wv-id" ||

--- a/src/sections/weaverse-element.ts
+++ b/src/sections/weaverse-element.ts
@@ -34,13 +34,6 @@ export function elementAttributes(
   props: WeaverseElementProps,
 ): Record<string, string> {
   const attributes: Record<string, string> = {};
-  /* The runtime keeps `id` for the item's own identity, so an authored anchor
-   * has to travel under its own name. It matters beyond anchors: a section
-   * labelled by its heading needs that heading to carry a stable id, and the
-   * heading is a child now. */
-  if (typeof props.elementId === "string" && props.elementId.length > 0) {
-    attributes.id = props.elementId;
-  }
   const forwarded = Object.keys(props).filter(
     (key) =>
       key === "data-wv-id" ||
@@ -53,6 +46,13 @@ export function elementAttributes(
     if (typeof value === "string" && value.length > 0) {
       attributes[key] = value;
     }
+  }
+  /* Applied after the loop on purpose: the runtime keeps `id` for the item's
+   * own identity, so an authored anchor travels under its own name and has to
+   * win when both are present. A section labelled by its heading needs that
+   * heading to carry the stable id, and the heading is a child now. */
+  if (typeof props.elementId === "string" && props.elementId.length > 0) {
+    attributes.id = props.elementId;
   }
   return attributes;
 }

--- a/tests/dom/composed-sections.test.tsx
+++ b/tests/dom/composed-sections.test.tsx
@@ -67,12 +67,9 @@ describe("image inputs survive Builder's own shape", () => {
 
   it("renders a Builder image in the editorial hero", () => {
     const { container } = render(
-      <EditorialHero
-        eyebrowLabel="Eyebrow"
-        heading="Heading"
-        lede="Lede"
-        image={BUILDER_IMAGE}
-      />,
+      <EditorialHero image={BUILDER_IMAGE}>
+        <p>Copy</p>
+      </EditorialHero>,
     );
 
     const image = container.querySelector("img");
@@ -81,17 +78,16 @@ describe("image inputs survive Builder's own shape", () => {
   });
 
   it("drops the image rather than crashing when it has no dimensions", () => {
+    /* The copy is children now, so the section keeps carrying it when the
+     * image is unusable rather than taking the route down with it. */
     const { container } = render(
-      <EditorialHero
-        eyebrowLabel="Eyebrow"
-        heading="Heading"
-        lede="Lede"
-        image={{ url: "https://cdn.example/hero.jpg" }}
-      />,
+      <EditorialHero image={{ url: "https://cdn.example/hero.jpg" }}>
+        <p>Copy</p>
+      </EditorialHero>,
     );
 
     assert.equal(container.querySelector("img"), null);
-    assert.ok(container.textContent?.includes("Heading"));
+    assert.ok(container.textContent?.includes("Copy"));
   });
 });
 

--- a/tests/weaverse-registry.test.ts
+++ b/tests/weaverse-registry.test.ts
@@ -84,6 +84,31 @@ describe("Weaverse registry split", () => {
     assert.deepEqual(empty, []);
   });
 
+  it("advertises no layout control a section cannot honour", async () => {
+    /* Declaring `layoutInputs` puts width, spacing and padding in Studio, but
+     * only `Section` reads them — everything else drops them in
+     * `elementAttributes`. Six sections have shipped that way across two
+     * rounds of this rework, each time invisible to every other gate because
+     * the storefront still looks right. */
+    const broken: string[] = [];
+    for (const schema of SECTION_SCHEMAS) {
+      const dir = `src/sections/${schema.type}`;
+      const [component, source] = await Promise.all([
+        read(`${dir}/index.tsx`).catch(() => null),
+        read(`${dir}/schema.ts`).catch(() => null),
+      ]);
+      if (component === null || source === null) continue;
+      if (
+        source.includes("layoutInputs") &&
+        !component.includes('from "@/components/section"')
+      ) {
+        broken.push(schema.type);
+      }
+    }
+
+    assert.deepEqual(broken, []);
+  });
+
   it("declares no duplicate component types", () => {
     assert.equal(
       new Set(SECTION_TYPES).size,

--- a/tests/weaverse-registry.test.ts
+++ b/tests/weaverse-registry.test.ts
@@ -71,6 +71,19 @@ describe("Weaverse registry split", () => {
     );
   });
 
+  it("declares no empty settings group", () => {
+    /* `createSchema` only warns on stderr for this, so a group left empty by
+     * an edit ships a schema Builder rejects while every gate stays green.
+     * Three sections reached that state during the container rework. */
+    const empty = SECTION_SCHEMAS.flatMap((schema) =>
+      (schema.settings ?? [])
+        .filter((group) => (group.inputs ?? []).length === 0)
+        .map((group) => `${schema.type} -> ${group.group}`),
+    );
+
+    assert.deepEqual(empty, []);
+  });
+
   it("declares no duplicate component types", () => {
     assert.equal(
       new Set(SECTION_TYPES).size,


### PR DESCRIPTION
Finishes the conversion #72 asked for. The last PR landed the machinery and converted two sections; this one converts eleven more, taking `childTypes` from **2 of 29 to 13 of 29** — Pilot, for reference, is 34 of 79.

## Converted

`home-hero`, `editorial-hero`, `editorial-overlay-hero`, `material-standard`, `system-manifest`, `collection-index`, `collection-grid`, `related-products`, `numbered-sequence`, `featured-products`, `standard-statement`.

Each owns its layout and its data; the copy is elements a merchant can restyle. `system-manifest` converts only its copy block, because its link renders after the product list and one child slot cannot interleave.

## Three defects the conversion produced, and what caught them

**Every converted masthead lost its `<h1>`.** The `heading` element defaults to `as: "h2"` and the presets did not ask otherwise, so `/`, `/about`, `/materials` and `/field-testing` had no top-level heading at all. Caught by the `smoke:routes` `<h1>` assertion added after the empty-template bug — the first time that gate has paid for itself.

**The home hero lost its accessible name.** The section is labelled by its heading's id, and the runtime keeps `id` for item identity, so a heading child could not carry it. Headings take an authored `elementId` now, which `elementAttributes` maps to `id`. That is a real control rather than a workaround — anchors need it too — and `featured-products` is its second use.

**Three schemas shipped an empty settings group.** Stripping the copy inputs left `Content: { inputs: [] }`, which `createSchema` only warns about on stderr. Typecheck, lint, 373 node tests, 136 DOM tests and the browser matrix were all green while Builder would have rejected the schema. There is a test for it now, verified by putting an empty group back and watching it fail.

## Not converted, and why

Sixteen sections stay flat. This is the complete list with reasons, not a deferral:

| | Why |
|---|---|
| `collection-hero`, `page-hero`, `article-header`, `page-premise` | their copy is the **resource** — `collection.title`, `page.intro`, `article.plate`. An element renders a fixed string, so converting would show every collection the same title. Binding an element to a resource field is an SDK capability, not something the theme can do. |
| `page-origin` | its image sits between the authored copy of one column, and there is no image element to nest |
| `product-strip` | its eyebrow uses `m-0 max-w-copy-narrow` rather than the shared `mb-3.5`, so converting would change its spacing |
| `article-body` | renders Shopify blocks verbatim |
| `page-values`, `product-tiles`, `stat-band`, `principle-grid` | data-driven lists with no editorial copy |
| `main-product` | the buy block; its logic stays in code |
| `kit-callout`, `product-spotlight` | viewport-height layouts whose copy is already minimal |

The resource-bound four are the only genuine blocker left, and it is not in this repo.

## Verification

Every gate re-run after **each** of the three batches, not once at the end:

```
bun run check               # 374 node + 136 DOM, build, theme, routes
bun run smoke:routes        # 35/35
bun run test:browser:static # 146 passed / 10 skipped / 0 failed
```

The project was reseeded after each batch and every route checked for its real `h1`.
